### PR TITLE
Replace Ophidian build and create push and pull methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.env
+.prettierrc

--- a/dev.config.mjs
+++ b/dev.config.mjs
@@ -1,0 +1,106 @@
+import Builder, {
+    addWatch as manufactureWatchFilesPluginItem,
+} from "@ophidian/build";
+import { copy } from "esbuild-plugin-copy";
+import { ensureFile } from "fs-extra";
+
+import sassPlugin from "esbuild-plugin-sass";
+import { basename, dirname, join, resolve } from "path";
+import copyNewer from "copy-newer";
+import dotenv from "dotenv";
+
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+
+const {
+    parsed: { OBSIDIAN_TEST_VAULT },
+} = dotenv.config({ path: "./.env" });
+
+const manifest = require("./manifest.json");
+
+// uses outfile as the source of output directory search
+const copyManifestPluginItem = manufactureCopyPluginItem({
+    assets: [{ from: ["manifest*"], to: ["manifest.json"] }],
+});
+const copyScssPluginItem = manufactureCopyPluginItem({
+    assets: [{ from: ["main.css"], to: ["styles.css"] }],
+});
+const sassPluginItem = sassPlugin();
+const installToDevVaultPluginItem = manufactureHotReloadPluginItem(
+    manifest.id,
+    true
+);
+
+new Builder("src/plugin.js")
+    .apply(
+        createPluginsUpdaterPredicate([
+            manufactureWatchFilesPluginItem(
+                new URL("", import.meta.url).pathname
+            ),
+        ])
+    )
+    .assign({ loader: { ".png": "dataurl" } })
+    .apply(createPluginsUpdaterPredicate([copyManifestPluginItem]))
+    .apply(createPluginsUpdaterPredicate([sassPluginItem, copyScssPluginItem]))
+    .apply(createPluginsUpdaterPredicate([installToDevVaultPluginItem]))
+    .build();
+
+function manufactureCopyPluginItemDefaultConfig() {
+    return {
+        verbose: false,
+        assets: [{ from: "", to: "" }],
+    };
+}
+function manufactureCopyPluginItem(
+    copyConfig = manufactureCopyPluginItemDefaultConfig()
+) {
+    const pluginItem = copy({
+        ...manufactureCopyPluginItemDefaultConfig(),
+        ...copyConfig,
+    });
+    return pluginItem;
+}
+
+function createPluginsUpdaterPredicate(plugins) {
+    return function (c) {
+        c.plugins.push(...plugins.filter(Boolean));
+        return this;
+    };
+}
+
+function manufactureHotReloadPluginItem(
+    pluginName = "plugin-installer",
+    hotreload
+) {
+    if (OBSIDIAN_TEST_VAULT) {
+        const destinationVaultPluginDir = join(
+            OBSIDIAN_TEST_VAULT,
+            ".obsidian/plugins",
+            basename(pluginName)
+        );
+        return {
+            name: "plugin-installer",
+            setup(build) {
+                build.onEnd(async () => {
+                    const srcBuildDir =
+                        build.initialOptions.outdir ??
+                        dirname(build.initialOptions.outfile);
+                    await copyNewer(
+                        "{main.js,styles.css,manifest.json}",
+                        destinationVaultPluginDir,
+                        {
+                            verbose: true,
+                            cwd: srcBuildDir,
+                        }
+                    );
+                    if (hotreload) {
+                        await ensureFile(
+                            destinationVaultPluginDir + "/.hotreload"
+                        );
+                    }
+                });
+            },
+        };
+    }
+    return null;
+}

--- a/ophidian.config.mjs
+++ b/ophidian.config.mjs
@@ -1,13 +1,12 @@
-import Builder from "ophidian/build";
+import Builder from 'ophidian/build';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 
-const manifest = require("./manifest.json");
+const manifest = require('./manifest.json');
 
-new Builder("src/plugin.js")
-.withWatch(new URL('', import.meta.url).pathname)
-.assign({loader: {'.png': 'dataurl'}})
-.withSass()
-.withInstall(manifest.id)
-.build();
-
+new Builder('src/plugin.js')
+  .withWatch(new URL('', import.meta.url).pathname)
+  .assign({ loader: { '.png': 'dataurl' } })
+  .withSass()
+  .withInstall(manifest.id)
+  .build();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "tag-wrangler",
   "scripts": {
+    "envdev": "node dev.config.mjs dev",
     "dev": "node ophidian.config.mjs dev",
     "build": "node ophidian.config.mjs production"
   },
   "license": "ISC",
   "devDependencies": {
+    "@ophidian/build": "^1.0.1",
+    "copy-newer": "^2.1.2",
+    "dotenv": "^16.1.3",
+    "esbuild-plugin-copy": "^2.1.1",
+    "esbuild-plugin-sass": "^1.0.1",
+    "fs-extra": "^11.1.1",
     "monkey-around": "^2.3",
     "obsidian": "^0.14.5",
     "ophidian": "github:pjeby/ophidian",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,12 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
+  '@ophidian/build': ^1.0.1
+  copy-newer: ^2.1.2
+  dotenv: ^16.1.3
+  esbuild-plugin-copy: ^2.1.1
+  esbuild-plugin-sass: ^1.0.1
+  fs-extra: ^11.1.1
   monkey-around: ^2.3
   obsidian: ^0.14.5
   ophidian: github:pjeby/ophidian
@@ -8,13 +14,26 @@ specifiers:
   yaml: 2.0.0-10
 
 devDependencies:
+  '@ophidian/build': 1.0.1
+  copy-newer: 2.1.2
+  dotenv: 16.1.3
+  esbuild-plugin-copy: 2.1.1
+  esbuild-plugin-sass: 1.0.1
+  fs-extra: 11.1.1
   monkey-around: 2.3.0
   obsidian: 0.14.8
-  ophidian: github.com/pjeby/ophidian/0af36f1bf028f874f5fbc289752529aa938014de
+  ophidian: github.com/pjeby/ophidian/7638db4cded07464dc15acda7f6118f0999f7804
   smalltalk: github.com/pjeby/smalltalk/7c3a5ba2c8f6363d050ab23ba95165d7d270a456
   yaml: 2.0.0-10
 
 packages:
+
+  /@babel/runtime/7.22.3:
+    resolution: {integrity: sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+    dev: true
 
   /@cloudcmd/create-element/2.0.2:
     resolution: {integrity: sha512-5b74qCgwEUx+GxzXC9Gwamgh4Rx5ouLSrCW+QbaBHWpxA5s1sw5i6MbSODfuts1MSX5RoaZjJAjNY5y3et1iXw==}
@@ -71,6 +90,18 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@ophidian/build/1.0.1:
+    resolution: {integrity: sha512-0JGtb1GdCIcC91qUM4GuWzySKIXNg0wvlDeDThAIpruzJjDS3w5OrBmx1XVHqksKHPml3zpuRYhD9eXPUx+sJA==}
+    dependencies:
+      builtin-modules: 3.3.0
+      copy-newer: 2.1.2
+      esbuild: 0.14.49
+      esbuild-plugin-copy: 1.3.0_esbuild@0.14.49
+      esbuild-plugin-sass: 1.0.1_esbuild@0.14.49
+      fs-extra: 10.1.0
+      monkey-around: 2.3.0
     dev: true
 
   /@types/codemirror/0.0.108:
@@ -189,7 +220,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /copy-newer/2.1.2:
@@ -226,6 +257,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /dotenv/16.1.3:
+    resolution: {integrity: sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==}
+    engines: {node: '>=12'}
     dev: true
 
   /esbuild-android-64/0.14.49:
@@ -383,6 +419,28 @@ packages:
       globby: 11.1.0
     dev: true
 
+  /esbuild-plugin-copy/2.1.1:
+    resolution: {integrity: sha512-Bk66jpevTcV8KMFzZI1P7MZKZ+uDcrZm2G2egZ2jNIvVnivDpodZI+/KnpL3Jnap0PBdIHU7HwFGB8r+vV5CVw==}
+    peerDependencies:
+      esbuild: '>= 0.14.0'
+    dependencies:
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      fs-extra: 10.1.0
+      globby: 11.1.0
+    dev: true
+
+  /esbuild-plugin-sass/1.0.1:
+    resolution: {integrity: sha512-YFxjzD9Z1vz92QCJcAmCO15WVCUiOobw9ypdVeMsW+xa6S+zqryLUIh8d3fe/UkRHRO5PODZz/3xDAQuEXZwmQ==}
+    peerDependencies:
+      esbuild: '>=0.11.14'
+    dependencies:
+      css-tree: 1.1.3
+      fs-extra: 10.0.0
+      sass: 1.47.0
+      tmp: 0.2.1
+    dev: true
+
   /esbuild-plugin-sass/1.0.1_esbuild@0.14.49:
     resolution: {integrity: sha512-YFxjzD9Z1vz92QCJcAmCO15WVCUiOobw9ypdVeMsW+xa6S+zqryLUIh8d3fe/UkRHRO5PODZz/3xDAQuEXZwmQ==}
     peerDependencies:
@@ -501,6 +559,15 @@ packages:
       universalify: 2.0.0
     dev: true
 
+  /fs-extra/11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.9
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-write-stream-atomic/1.0.10:
     resolution: {integrity: sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==}
     dependencies:
@@ -586,6 +653,12 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /i18next/20.6.1:
+    resolution: {integrity: sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==}
+    dependencies:
+      '@babel/runtime': 7.22.3
     dev: true
 
   /iferr/0.1.5:
@@ -687,12 +760,12 @@ packages:
       minimist: 1.2.5
     dev: true
 
-  /moment/2.29.1:
-    resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}
-    dev: true
-
   /moment/2.29.2:
     resolution: {integrity: sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==}
+    dev: true
+
+  /moment/2.29.4:
+    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: true
 
   /monkey-around/2.3.0:
@@ -709,15 +782,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /obsidian/0.14.5:
-    resolution: {integrity: sha512-ka3DuL+iel+olMq3XlVQ06FtpYwIqUeKjyy+RUHeD0p84fp5DyxUL//r0CTczdmiVAvYprzb64NxghFI+E1slg==}
-    dependencies:
-      '@codemirror/state': 0.19.8
-      '@codemirror/view': 0.19.42
-      '@types/codemirror': 0.0.108
-      moment: 2.29.1
-    dev: true
-
   /obsidian/0.14.8:
     resolution: {integrity: sha512-CQz+B2HSbhGVEBwZBL3rPl29ruOBmEhCbBmW7PIILnnRh6fFFvYy3kZLHVTUidzvRGZnEW/mQ7n9LXeJCp2a/Q==}
     dependencies:
@@ -725,6 +789,16 @@ packages:
       '@codemirror/view': 0.19.42
       '@types/codemirror': 0.0.108
       moment: 2.29.2
+    dev: true
+
+  /obsidian/0.15.9:
+    resolution: {integrity: sha512-w3JL/IM3/U61rjFSFIFDSv+pcHn3mH1EIRN40kBkC/lGYqjFSPbr6daQe08QkskBz/GAYIeBoaKQIcgU9vV3LQ==}
+    peerDependencies:
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+    dependencies:
+      '@types/codemirror': 0.0.108
+      moment: 2.29.4
     dev: true
 
   /once/1.4.0:
@@ -790,6 +864,10 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+    dev: true
+
+  /regenerator-runtime/0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
     dev: true
 
   /reusify/1.0.4:
@@ -896,20 +974,18 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  github.com/pjeby/ophidian/0af36f1bf028f874f5fbc289752529aa938014de:
-    resolution: {tarball: https://codeload.github.com/pjeby/ophidian/tar.gz/0af36f1bf028f874f5fbc289752529aa938014de}
-    name: ophidian
-    version: 0.0.1
+  github.com/pjeby/ophidian/7638db4cded07464dc15acda7f6118f0999f7804:
+    resolution: {commit: 7638db4cded07464dc15acda7f6118f0999f7804, repo: git+ssh://git@github.com/pjeby/ophidian.git, type: git}
+    name: '@ophidian/core'
+    version: 0.0.12
     dependencies:
-      builtin-modules: 3.3.0
-      copy-newer: 2.1.2
-      esbuild: 0.14.49
-      esbuild-plugin-copy: 1.3.0_esbuild@0.14.49
-      esbuild-plugin-sass: 1.0.1_esbuild@0.14.49
-      fs-extra: 10.1.0
+      i18next: 20.6.1
       monkey-around: 2.3.0
-      obsidian: 0.14.5
+      obsidian: 0.15.9
       to-use: 0.2.1
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: true
 
   github.com/pjeby/smalltalk/7c3a5ba2c8f6363d050ab23ba95165d7d270a456:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,142 +1,211 @@
-import {Component, Keymap, Menu, Notice, parseFrontMatterAliases, Plugin, Scope} from "obsidian";
-import {renameTag, findTargets} from "./renaming";
-import {Tag} from "./Tag";
-import {around} from "monkey-around";
+import {
+    Component,
+    Keymap,
+    Menu,
+    Notice,
+    parseFrontMatterAliases,
+    Plugin,
+    Scope,
+} from "obsidian";
+import { renameTag, findTargets } from "./renaming";
+import { Tag } from "./Tag";
+import { around } from "monkey-around";
 
 const tagHoverMain = "tag-wrangler:tag-pane";
 
 function onElement(el, event, selector, callback, options) {
-    el.on(event, selector, callback, options)
+    el.on(event, selector, callback, options);
     return () => el.off(event, selector, callback, options);
 }
 
 export default class TagWrangler extends Plugin {
     pageAliases = new Map();
     tagPages = new Map();
+    customCreateTagPage = false;
 
     tagPage(tag) {
-        return Array.from(this.tagPages.get(Tag.canonical(tag)) || "")[0]
+        return Array.from(this.tagPages.get(Tag.canonical(tag)) || "")[0];
     }
 
     openTagPage(file, isNew, newLeaf) {
         const openState = {
-            eState: isNew ? {rename: "all"} : {focus: true},  // Rename new page, focus existing
-            ...(isNew ? {state: {mode: "source"}} : {})       // and set source mode for new page
-        }
+            eState: isNew ? { rename: "all" } : { focus: true }, // Rename new page, focus existing
+            ...(isNew ? { state: { mode: "source" } } : {}), // and set source mode for new page
+        };
         return this.app.workspace.getLeaf(newLeaf).openFile(file, openState);
     }
 
     async createTagPage(tagName, newLeaf) {
         const baseName = new Tag(tagName).name.split("/").join(" ");
-        const folder = this.app.fileManager.getNewFileParent(this.app.workspace.getActiveFile()?.path || "");
-        const path = this.app.vault.getAvailablePath(folder.getParentPrefix()+baseName, "md");
-        this.openTagPage(await this.app.vault.create(path, [
-            "---",
-            `Aliases: [ ${JSON.stringify(Tag.toTag(tagName))} ]`,
-            "---",
-            ""
-        ].join("\n")), true, newLeaf);
-    }
-
-    async onload(){
-        this.register(
-            onElement(document, "contextmenu", ".tag-pane-tag", this.onMenu.bind(this), {capture: true})
+        const folder = this.app.fileManager.getNewFileParent(
+            this.app.workspace.getActiveFile()?.path || ""
+        );
+        const middle = "testfolder";
+        const path = this.app.vault.getAvailablePath(
+            `${folder.getParentPrefix()}/${middle}/${baseName}`,
+            "md"
         );
 
-        this.app.workspace.registerHoverLinkSource(tagHoverMain, {display: 'Tag pane', defaultMod: true});
+        this.openTagPage(await this.app.vault.create(path, ""), true, newLeaf);
+    }
+
+    async onload() {
+        this.register(
+            onElement(
+                document,
+                "contextmenu",
+                ".tag-pane-tag",
+                this.onMenu.bind(this),
+                { capture: true }
+            )
+        );
+
+        this.app.workspace.registerHoverLinkSource(tagHoverMain, {
+            display: "Tag pane",
+            defaultMod: true,
+        });
 
         this.addChild(
             // Tags in the tag pane
             new TagPageUIHandler(this, {
-                hoverSource: tagHoverMain, selector: ".tag-pane-tag", container: ".tag-container",
-                toTag(el) { return el.find(".tag-pane-tag-text, tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text")?.textContent; }
+                hoverSource: tagHoverMain,
+                selector: ".tag-pane-tag",
+                container: ".tag-container",
+                toTag(el) {
+                    return el.find(
+                        ".tag-pane-tag-text, tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text"
+                    )?.textContent;
+                },
             })
         );
 
         this.addChild(
             // Reading mode / tag links
             new TagPageUIHandler(this, {
-                hoverSource: "preview", selector: 'a.tag[href^="#"]',
-                container: ".markdown-preview-view, .markdown-embed, .workspace-leaf-content",
-                toTag(el) { return el.getAttribute("href"); }
+                hoverSource: "preview",
+                selector: 'a.tag[href^="#"]',
+                container:
+                    ".markdown-preview-view, .markdown-embed, .workspace-leaf-content",
+                toTag(el) {
+                    return el.getAttribute("href");
+                },
             })
         );
 
         this.addChild(
             // Edit mode
             new TagPageUIHandler(this, {
-                hoverSource: "editor", selector: "span.cm-hashtag",
+                hoverSource: "editor",
+                selector: "span.cm-hashtag",
                 container: ".markdown-source-view",
                 toTag(el) {
                     // Multiple cm-hashtag elements can be side by side: join them all together:
                     let tagName = el.textContent;
-                    if (!el.matches(".cm-formatting")) for (let t=el.previousElementSibling; t?.matches("span.cm-hashtag:not(.cm-formatting)"); t = t.previousElementSibling) {
-                        tagName = t.textContent + tagName;
-                    }
-                    for (let t=el.nextElementSibling; t?.matches("span.cm-hashtag:not(.cm-formatting)"); t = t.nextElementSibling) {
+                    if (!el.matches(".cm-formatting"))
+                        for (
+                            let t = el.previousElementSibling;
+                            t?.matches("span.cm-hashtag:not(.cm-formatting)");
+                            t = t.previousElementSibling
+                        ) {
+                            tagName = t.textContent + tagName;
+                        }
+                    for (
+                        let t = el.nextElementSibling;
+                        t?.matches("span.cm-hashtag:not(.cm-formatting)");
+                        t = t.nextElementSibling
+                    ) {
                         tagName += t.textContent;
                     }
                     return tagName;
-                }
+                },
             })
         );
 
-
         // Tag Drag
         this.register(
-            onElement(document, "pointerdown", ".tag-pane-tag", (_, targetEl) => {
-                targetEl.draggable = "true";
-            }, {capture: true})
+            onElement(
+                document,
+                "pointerdown",
+                ".tag-pane-tag",
+                (_, targetEl) => {
+                    targetEl.draggable = "true";
+                },
+                { capture: true }
+            )
         );
         this.register(
-            onElement(document, "dragstart", ".tag-pane-tag", (event, targetEl) => {
-                const tagName = targetEl.find(".tag-pane-tag-text, tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text")?.textContent;
-                event.dataTransfer.setData("text/plain", "#"+tagName);
-                app.dragManager.onDragStart(event, {
-                    source: "tag-wrangler",
-                    type: "text",
-                    title: tagName,
-                    icon: "hashtag",
-                })
-            }, {capture: false})
+            onElement(
+                document,
+                "dragstart",
+                ".tag-pane-tag",
+                (event, targetEl) => {
+                    const tagName = targetEl.find(
+                        ".tag-pane-tag-text, tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text"
+                    )?.textContent;
+                    event.dataTransfer.setData("text/plain", "#" + tagName);
+                    app.dragManager.onDragStart(event, {
+                        source: "tag-wrangler",
+                        type: "text",
+                        title: tagName,
+                        icon: "hashtag",
+                    });
+                },
+                { capture: false }
+            )
         );
 
         // Track Tag Pages
         const metaCache = this.app.metadataCache;
         const plugin = this;
 
-        this.register(around(metaCache, {
-            getTags(old) {
-                return function getTags() {
-                    const tags = old.call(this);
-                    const names = new Set(Object.keys(tags).map(t => t.toLowerCase()));
-                    for (const t of plugin.tagPages.keys()) {
-                        if (!names.has(t)) tags[plugin.tagPages.get(t).tag] = 0;
-                    }
-                    return tags;
-                }
-            }
-        }));
+        this.register(
+            around(metaCache, {
+                getTags(old) {
+                    return function getTags() {
+                        const tags = old.call(this);
+                        const names = new Set(
+                            Object.keys(tags).map((t) => t.toLowerCase())
+                        );
+                        for (const t of plugin.tagPages.keys()) {
+                            if (!names.has(t))
+                                tags[plugin.tagPages.get(t).tag] = 0;
+                        }
+                        return tags;
+                    };
+                },
+            })
+        );
 
         this.app.workspace.onLayoutReady(() => {
-            metaCache.getCachedFiles().forEach(filename => {
+            metaCache.getCachedFiles().forEach((filename) => {
                 const fm = metaCache.getCache(filename)?.frontmatter;
-                if (fm && parseFrontMatterAliases(fm)?.filter(Tag.isTag)) this.updatePage(
-                    this.app.vault.getAbstractFileByPath(filename), fm
-                );
+                if (fm && parseFrontMatterAliases(fm)?.filter(Tag.isTag))
+                    this.updatePage(
+                        this.app.vault.getAbstractFileByPath(filename),
+                        fm
+                    );
             });
-            this.registerEvent(metaCache.on("changed", (file, data, cache) => this.updatePage(file, cache?.frontmatter)));
-            this.registerEvent(this.app.vault.on("delete", file => this.updatePage(file)));
-            app.workspace.getLeavesOfType("tag").forEach(leaf => {leaf?.view?.requestUpdateTags?.()});
+            this.registerEvent(
+                metaCache.on("changed", (file, data, cache) =>
+                    this.updatePage(file, cache?.frontmatter)
+                )
+            );
+            this.registerEvent(
+                this.app.vault.on("delete", (file) => this.updatePage(file))
+            );
+            app.workspace.getLeavesOfType("tag").forEach((leaf) => {
+                leaf?.view?.requestUpdateTags?.();
+            });
         });
     }
 
     updatePage(file, frontmatter) {
-        const tags = parseFrontMatterAliases(frontmatter)?.filter(Tag.isTag) || [];
+        const tags =
+            parseFrontMatterAliases(frontmatter)?.filter(Tag.isTag) || [];
         if (this.pageAliases.has(file)) {
             const oldTags = new Set(tags || []);
             for (const tag of this.pageAliases.get(file)) {
-                if (oldTags.has(tag)) continue;  // don't bother deleting what we'll just put back
+                if (oldTags.has(tag)) continue; // don't bother deleting what we'll just put back
                 const key = Tag.canonical(tag);
                 const tp = this.tagPages.get(key);
                 if (tp) {
@@ -163,128 +232,209 @@ export default class TagWrangler extends Plugin {
     onMenu(e, tagEl) {
         if (!e.obsidian_contextmenu) {
             e.obsidian_contextmenu = new Menu(this.app);
-            setTimeout(() => menu.showAtPosition({x: e.pageX, y: e.pageY}), 0);
+            setTimeout(
+                () => menu.showAtPosition({ x: e.pageX, y: e.pageY }),
+                0
+            );
         }
 
-        const
-            tagName = tagEl.find(".tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text").textContent,
+        const tagName = tagEl.find(
+                ".tag-pane-tag-text, .tag-pane-tag .tree-item-inner-text"
+            ).textContent,
             tagPage = this.tagPage(tagName),
-            isHierarchy = tagEl.parentElement.parentElement.find(".collapse-icon"),
-            searchPlugin = this.app.internalPlugins.getPluginById("global-search"),
+            isHierarchy =
+                tagEl.parentElement.parentElement.find(".collapse-icon"),
+            searchPlugin =
+                this.app.internalPlugins.getPluginById("global-search"),
             search = searchPlugin && searchPlugin.instance,
             query = search && search.getGlobalSearchQuery(),
             random = this.app.plugins.plugins["smart-random-note"],
-            menu = e.obsidian_contextmenu.addItem(item("pencil", "Rename #"+tagName, () => this.rename(tagName)));
-
+            menu = e.obsidian_contextmenu.addItem(
+                item("pencil", "Rename #" + tagName, () => this.rename(tagName))
+            );
         menu.addSeparator();
-        if (tagPage) {
+
+        if (this.customCreateTagPage) {
+            this.app.workspace.trigger(
+                "tag-wrangler:customCreateTagPage",
+                menu,
+                tagName,
+                {
+                    search,
+                    query,
+                    isHierarchy,
+                    tagPage,
+                    Keymap,
+                }
+            );
+        } else if (tagPage) {
             menu.addItem(
-                item("popup-open", "Open tag page", (e) => this.openTagPage(tagPage, false, Keymap.isModEvent(e)))
-            )
+                item("popup-open", "Open tag page", (e) =>
+                    this.openTagPage(tagPage, false, Keymap.isModEvent(e))
+                )
+            );
         } else {
             menu.addItem(
-                item("create-new", "Create tag page", (e) => this.createTagPage(tagName, Keymap.isModEvent(e)))
-            )
+                item("create-new", "Create tag page", (e) =>
+                    this.createTagPage(tagName, Keymap.isModEvent(e))
+                )
+            );
         }
 
         if (search) {
             menu.addSeparator().addItem(
-                item("magnifying-glass", "New search for #"+tagName, () => search.openGlobalSearch("tag:" + tagName))
+                item("magnifying-glass", "New search for #" + tagName, () =>
+                    search.openGlobalSearch("tag:" + tagName)
+                )
             );
             if (query) {
                 menu.addItem(
-                    item("sheets-in-box", "Require #"+tagName+" in search"  , () => search.openGlobalSearch(query+" tag:"  + tagName))
+                    item(
+                        "sheets-in-box",
+                        "Require #" + tagName + " in search",
+                        () => search.openGlobalSearch(query + " tag:" + tagName)
+                    )
                 );
             }
             menu.addItem(
-                item("crossed-star" , "Exclude #"+tagName+" from search", () => search.openGlobalSearch(query+" -tag:" + tagName))
+                item(
+                    "crossed-star",
+                    "Exclude #" + tagName + " from search",
+                    () => search.openGlobalSearch(query + " -tag:" + tagName)
+                )
             );
         }
 
         if (random) {
             menu.addSeparator().addItem(
                 item("dice", "Open random note", async () => {
-                    const targets = await findTargets(this.app, new Tag(tagName));
-                    random.openRandomNote(targets.map(f=> this.app.vault.getAbstractFileByPath(f.filename)));
+                    const targets = await findTargets(
+                        this.app,
+                        new Tag(tagName)
+                    );
+                    random.openRandomNote(
+                        targets.map((f) =>
+                            this.app.vault.getAbstractFileByPath(f.filename)
+                        )
+                    );
                 })
             );
         }
 
-        this.app.workspace.trigger("tag-wrangler:contextmenu", menu, tagName, {search, query, isHierarchy, tagPage});
+        this.app.workspace.trigger("tag-wrangler:contextmenu", menu, tagName, {
+            search,
+            query,
+            isHierarchy,
+            tagPage,
+        });
 
         if (isHierarchy) {
-            const
-                tagParent = tagName.split("/").slice(0, -1).join("/"),
+            const tagParent = tagName.split("/").slice(0, -1).join("/"),
                 tagView = this.leafView(tagEl.matchParent(".workspace-leaf")),
-                tagContainer = tagParent ? tagView.tagDoms["#" + tagParent.toLowerCase()]: tagView.root
-            ;
+                tagContainer = tagParent
+                    ? tagView.tagDoms["#" + tagParent.toLowerCase()]
+                    : tagView.root;
             function toggle(collapse) {
-                for(const tag of tagContainer.children ?? tagContainer.vChildren.children) tag.setCollapsed(collapse);
+                for (const tag of tagContainer.children ??
+                    tagContainer.vChildren.children)
+                    tag.setCollapsed(collapse);
             }
             menu.addSeparator()
-            .addItem(item("vertical-three-dots", "Collapse tags at this level", () => toggle(true )))
-            .addItem(item("expand-vertically"  , "Expand tags at this level"  , () => toggle(false)))
+                .addItem(
+                    item(
+                        "vertical-three-dots",
+                        "Collapse tags at this level",
+                        () => toggle(true)
+                    )
+                )
+                .addItem(
+                    item("expand-vertically", "Expand tags at this level", () =>
+                        toggle(false)
+                    )
+                );
         }
     }
 
     leafView(containerEl) {
         let view;
         this.app.workspace.iterateAllLeaves((leaf) => {
-            if (leaf.containerEl === containerEl) { view = leaf.view; return true; }
-        })
+            if (leaf.containerEl === containerEl) {
+                view = leaf.view;
+                return true;
+            }
+        });
         return view;
     }
 
-
     async rename(tagName) {
-        const scope = new Scope;
+        const scope = new Scope();
         this.app.keymap.pushScope(scope);
-        try { await renameTag(this.app, tagName); }
-        catch (e) { console.error(e); new Notice("error: " + e); }
+        try {
+            await renameTag(this.app, tagName);
+        } catch (e) {
+            console.error(e);
+            new Notice("error: " + e);
+        }
         this.app.keymap.popScope(scope);
     }
-
 }
 
 function item(icon, title, click) {
-    return i => i.setIcon(icon).setTitle(title).onClick(click);
+    return (i) => i.setIcon(icon).setTitle(title).onClick(click);
 }
-
 
 class TagPageUIHandler extends Component {
     // Handle hovering and clicks-to-open for tag pages
 
     constructor(plugin, opts) {
         super();
-        this.opts = opts
+        this.opts = opts;
         this.plugin = plugin;
     }
 
     onload() {
-        const {selector, container, hoverSource, toTag} = this.opts;
+        const { selector, container, hoverSource, toTag } = this.opts;
         this.register(
             // Show tag page on hover
-            onElement(document, "mouseover", selector, (event, targetEl) => {
-                const tagName = toTag(targetEl), tp = tagName && this.plugin.tagPage(tagName);
-                if (tp) this.plugin.app.workspace.trigger('hover-link', {
-                    event, source: hoverSource, targetEl, linktext: tp.path,
-                    hoverParent: targetEl.matchParent(container)
-                });
-            }, {capture: false})
+            onElement(
+                document,
+                "mouseover",
+                selector,
+                (event, targetEl) => {
+                    const tagName = toTag(targetEl),
+                        tp = tagName && this.plugin.tagPage(tagName);
+                    if (tp)
+                        this.plugin.app.workspace.trigger("hover-link", {
+                            event,
+                            source: hoverSource,
+                            targetEl,
+                            linktext: tp.path,
+                            hoverParent: targetEl.matchParent(container),
+                        });
+                },
+                { capture: false }
+            )
         );
         this.register(
             // Open tag page w/alt click (current pane) or ctrl/cmd/middle click (new pane)
-            onElement(document, "click", selector, (event, targetEl) => {
-                const {altKey} = event;
-                if (!Keymap.isModEvent(event) && !altKey) return;
-                const tagName = toTag(targetEl), tp = tagName && this.plugin.tagPage(tagName);
-                if (tp) {
-                    this.plugin.openTagPage(tp, false, !altKey);
-                    event.preventDefault();
-                    event.stopPropagation();
-                    return false;
-                }
-            }, {capture: true})
+            onElement(
+                document,
+                "click",
+                selector,
+                (event, targetEl) => {
+                    const { altKey } = event;
+                    if (!Keymap.isModEvent(event) && !altKey) return;
+                    const tagName = toTag(targetEl),
+                        tp = tagName && this.plugin.tagPage(tagName);
+                    if (tp) {
+                        this.plugin.openTagPage(tp, false, !altKey);
+                        event.preventDefault();
+                        event.stopPropagation();
+                        return false;
+                    }
+                },
+                { capture: true }
+            )
         );
     }
 }


### PR DESCRIPTION
I considered the proposed solutions.
* 1) create tag pages by making notes in that folder, then allow secondary action from tag-wrangler.
* 2) use a template that checks every new note and if it's a fresh/empty tag note, to automatically move/rename/expand it and otherwise leave it alone.)

I've placed two criteria, a) minimum code effort(to avoid feature creep)  
and b) ease of use (1-click) 
Neither solutions proposed accomplish constraint b

## Event Driven (push-based) Solution

Your 3rd solution, i've created as follows. The difference is the allowing of a flag called this.customCreateTagPage for the create Tag Page trigger. This removes the create Page entirely and opens up the api to the user for creating a new menu item. Code work involves an if statement, and opening up your menu to an outside party. It would probably be safer to create some open apis rather than share the entire menu. Since the main goal is to create a folder , i think just sharing the create
![revealapi2](https://github.com/pjeby/tag-wrangler/assets/29618692/44226ece-e98a-4933-815f-1590448da930)
```js
export default class TagWrangler extends Plugin {
   onMenu() {
      if (this.customCreateTagPage) {
        this.app.workspace.trigger(
          'tag-wrangler:customCreateTagPage',  
          menu,
          tagName,
          {
            createTagPage: this.createTagPage,
            search,
            query,
            isHierarchy,
            tagPage,
            Keymap,
          }
        );
        console.log('hey');
      } else if (tagPage) {
        ....
      )
```

## Pull Based Solution

The user will set a property on the plugin instance (userSetTagFolderName) , if this is detected, the path updates to the folder name. As long as the file is completely empty, Templater will automatically trigger a template specific for that folder.

![empty](https://github.com/pjeby/tag-wrangler/assets/29618692/be027fe0-3c30-474e-931f-c3421b6cec0d)
```js
  async createTagPage(tagName, newLeaf) {
    const baseName = new Tag(tagName).name.split('/').join(' ');
    const folder = this.app.fileManager.getNewFileParent(
      this.app.workspace.getActiveFile()?.path || ''
    );
    const folderName = this.userSetTagFolderName ? : '/' + this.userSetTagFolderName +'/' : '';
    const path = this.app.vault.getAvailablePath(
      folder.getParentPrefix() + folderName + baseName,
      'md'
    );
    this.openTagPage(
      await this.app.vault.create(
        path,
    );
  }
  ```
  
  The Pull Based Solution uses the least amount of code. The Push based solution is probably the BEST one if you are looking to EXTEND your api.
  
  Both solutions require setting a public property (a toggler) on the instance of tag-wrangler to activate.
  
  PS: (it turns out that i use a ton of your stuff already. althought I had to replace ophidian so that i could run tag wrangler on my computer. Let me know what the right way to dev your app.)
  
  If no one sets that flag in the tag wrangler instance, behavior is unchanged.(which i believe was a priority for you)