### PR TITLE
Set up json for tradional chinese and english.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@ophidian/build': ^1.0.2
@@ -10,7 +10,7 @@ specifiers:
 
 devDependencies:
   '@ophidian/build': 1.0.2
-  '@ophidian/core': github.com/ophidian-lib/core/7638db4cded07464dc15acda7f6118f0999f7804
+  '@ophidian/core': github.com/ophidian-lib/core/bba05f28ffc0a569862f2af5178e5dbe9fc21b11
   monkey-around: 2.3.0
   obsidian: 0.14.8
   smalltalk: github.com/pjeby/smalltalk/7c3a5ba2c8f6363d050ab23ba95165d7d270a456
@@ -240,6 +240,11 @@ packages:
 
   /currify/4.0.0:
     resolution: {integrity: sha512-ABfH28PWp5oqqp31cLXJQdeMqoFNej9rJOu84wKhN3jPCH7FAZg3zY1MVI27PTFoqfPlxOyhGmh9PzOVv+yN2g==}
+    dev: true
+
+  /defaults/2.0.1:
+    resolution: {integrity: sha512-1bGZaOcfpx0Iyxc0SqSIJ8O2WZF8xm56p4Yd4be+VxYQlFM5/4Mx3IMZqi96Npl8EsBG2pePlyGVLdqsmtIkag==}
+    engines: {node: '>=16'}
     dev: true
 
   /dir-glob/3.0.1:
@@ -745,8 +750,8 @@ packages:
       moment: 2.29.2
     dev: true
 
-  /obsidian/0.15.9:
-    resolution: {integrity: sha512-w3JL/IM3/U61rjFSFIFDSv+pcHn3mH1EIRN40kBkC/lGYqjFSPbr6daQe08QkskBz/GAYIeBoaKQIcgU9vV3LQ==}
+  /obsidian/1.2.8:
+    resolution: {integrity: sha512-HrC+feA8o0tXspj4lEAqxb1btwLwHD2oHXSwbbN+CdRHURqbCkuIDLld+nkuyJ1w1c9uvVDRVk8BoeOnWheOrQ==}
     peerDependencies:
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
@@ -902,8 +907,8 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /to-use/0.2.1:
-    resolution: {integrity: sha512-FwF0QIePeaY/Wk2thTjjV41KltJZsMTidH33R64u76Ai+IDyXI4cLYA5PH2PjQRyxAKVtDgcN1ZPK5JJh102Vw==}
+  /to-use/0.3.2:
+    resolution: {integrity: sha512-BsjW4JlQkMrZ9THFFkC4w5Yv3+dXAnd6Ycrm78heY3rNN6LxkBG0c0BQmn84qlMWxIkny1KmphU5wPMmRwMGhQ==}
     dev: true
 
   /universalify/2.0.0:
@@ -928,15 +933,16 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  github.com/ophidian-lib/core/7638db4cded07464dc15acda7f6118f0999f7804:
-    resolution: {tarball: https://codeload.github.com/ophidian-lib/core/tar.gz/7638db4cded07464dc15acda7f6118f0999f7804}
+  github.com/ophidian-lib/core/bba05f28ffc0a569862f2af5178e5dbe9fc21b11:
+    resolution: {tarball: https://codeload.github.com/ophidian-lib/core/tar.gz/bba05f28ffc0a569862f2af5178e5dbe9fc21b11}
     name: '@ophidian/core'
-    version: 0.0.12
+    version: 0.0.19
     dependencies:
+      defaults: 2.0.1
       i18next: 20.6.1
       monkey-around: 2.3.0
-      obsidian: 0.15.9
-      to-use: 0.2.1
+      obsidian: 1.2.8
+      to-use: 0.3.2
     transitivePeerDependencies:
       - '@codemirror/state'
       - '@codemirror/view'

--- a/src/i18next/locale.ts
+++ b/src/i18next/locale.ts
@@ -1,0 +1,42 @@
+import { moment } from 'obsidian';
+import * as resources from './locales'
+
+type I18Config = ReturnType<typeof manuI18Config>
+export const i18next = (async function(global, factory) {
+    
+  const i18next = global.i18next
+  if (i18next) {
+    return await factory(i18next)
+  }
+  throw new Error("No instance of i18 found.")
+})(
+  globalThis, 
+  async function factory(i18, config = manuI18Config()) {
+    const current_lang = moment.locale();
+    const _config: I18Config = {
+      ...manuI18Config(),
+      lng: current_lang,
+      ...config
+    }
+    // middleware
+    await i18.init(_config)
+    return i18;
+  }
+);
+  
+
+function manuI18Config(config = {}) {
+  return ({
+    lng: 'en',
+    debug: true,
+    defaultNS: "translation",
+    ns: "translation",
+    resources,
+    ...config
+  })
+};
+
+
+
+
+

--- a/src/i18next/locales/en.ts
+++ b/src/i18next/locales/en.ts
@@ -1,0 +1,25 @@
+export const RENAME = "Rename";
+export const CREATE_TAG_PAGE = "Create tag page";
+export const CREATE_A_TAG = "Create A Tag";
+export const OPEN_TAG_PAGE = "Open tag page";
+export const NEW_SEARCH_FOR = "New search for";
+export const REQUIRE = "Require";
+export const IN_SEARCH = "in search";
+export const EXCLUDE = "Exclude";
+export const FROM_SEARCH = "from search";
+export const enKeys = [
+  RENAME, 
+  CREATE_TAG_PAGE, 
+  CREATE_A_TAG,
+  OPEN_TAG_PAGE,
+  NEW_SEARCH_FOR,
+  REQUIRE,
+  IN_SEARCH,
+  EXCLUDE,
+  FROM_SEARCH
+] as const;
+
+const _en = enKeys.map((en_key) => ([en_key, en_key]))
+export default {
+  translation: Object.fromEntries(_en)
+}

--- a/src/i18next/locales/index.ts
+++ b/src/i18next/locales/index.ts
@@ -1,0 +1,3 @@
+
+export {default as en} from "./en"
+export {default as zhTW} from "./zh-tw"

--- a/src/i18next/locales/zh-tw.ts
+++ b/src/i18next/locales/zh-tw.ts
@@ -1,0 +1,29 @@
+import {enKeys, REQUIRE, IN_SEARCH, EXCLUDE, FROM_SEARCH, OPEN_TAG_PAGE} from "./en"
+type tKey = typeof enKeys[number]
+
+type PartialTranslation = Partial<Record<tKey,string>>
+type Namespace = "translation"
+
+const translation: PartialTranslation = {
+    "Rename": "重命名",
+    ["Create A Tag"]: "创建標籤",
+    ["Create tag page"]: "创建標籤葉",
+    ["New search for"]: "重新搜索",
+    [OPEN_TAG_PAGE]: "打開標簽葉",
+    [REQUIRE]: "必须先包含",
+    [IN_SEARCH]: "然后搜索",
+    [EXCLUDE]: "排除",
+    [FROM_SEARCH]: "在搜索之外",
+  }
+ 
+
+
+type TranslationObject = {
+  [K in Namespace]: PartialTranslation;
+};
+
+const translationObject: TranslationObject = {
+  translation,
+};
+
+export default translationObject;


### PR DESCRIPTION
* Locales have two dictionaries, one for english, one for traditional chinese. 
  * I am also available to do the simplified if necessary.
* The canonical system used will be based on https://github.com/mgmeyers/obsidian-kanban/blob/05e43e09100f8c8efd7a4cd5ccb391b850e65f28/src/lang/helpers.ts#L53

* locale.ts is our module based off jquery. Allows for future middle ware. Inside the IIFE parameters as well as provide an area  to intercept changes required by Android/IOS (**not implemented**)

* The onLoad fn housed inside of the Plugin Instance has the bootup code. Should the module fail to load, the translate default function will default to english (tested) and a error will console out via try catch.

* moment.locale is used to detect the desired language. i18.changeLanguage() with empty parameters will also run auto detection , and with paramters will change the language. But having settings isn't your style. Myers used window.localStorage for his knobs. (i have no opinion on this matter.)

* zhTW dictionary is a partial and does not require any of the words
  * Should the zhTW dictionary not have the word, it defaults to english. 
* Example of adding a new translated word.
  * Add the constants in the locale located in the filepath locale/en.ts  (the data starts/flows from the english dictionary.)
    * CRITICAL: you must add the constant to the enkeys array
  * Import the constant to your component (plugin.js)
    * The enkeys will automatically populate the state builder inside the onload function. 
  * i18nextInstance houses the api for i18next.
  * The finals step is to replace the messages with the updated dictionary values.
    * this.it[CONSTANT] will then translate accordingly.


![i18-pr](https://github.com/pjeby/tag-wrangler/assets/29618692/63aaa4fb-37a7-4fd0-a07f-fbf2ad3e9498)



* Oversights
  * I have not tested on mobile.