### PR TITLE
Add scoped tag list settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Also, make sure that you have enabled the "Tags View" plugin, in the "Core Plugi
 
 
 
+## Scoped Tag List
+
+Tag Wrangler can optionally filter the tags shown in the Tags view from its settings tab.  This is disabled by default.
+
+The tag allow list accepts exact tag names such as `#review`, subtree rules such as `#area/*`, and simple wildcard rules.  When at least one tag rule is enabled, only matching tags are shown.
+
+The file scope list accepts include and exclude path rules.  Folder paths such as `Projects/` match everything inside the folder, and wildcard path rules are supported.  If no include rules are enabled, all files are included before exclude rules are applied.
+
+These settings only affect the tag set returned to the Tags view while Tag Wrangler is enabled.  They do not hide files from Obsidian, and the files remain available to search, links, backlinks, and other vault features.
+
+
+
 ## Tag Pages
 
 People often debate the merits of using tags vs. page links to organize your notes.  With tag pages, you can combine the best of both worlds: the visibility and fluid entry of tags, plus the centralized content and outbound linking of a page.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,6 +3,9 @@ import {renameTag, findTargets} from "./renaming";
 import {Tag} from "./Tag";
 import {around} from "monkey-around";
 import {Confirm, use} from "@ophidian/core";
+import {TagWranglerSettingTab} from "./settings";
+import {buildScopedTags, normalizeSettings} from "./scope";
+import "./styles.scss";
 
 const tagHoverMain = "tag-wrangler:tag-pane";
 
@@ -15,6 +18,7 @@ export default class TagWrangler extends Plugin {
     use = use.plugin(this);
     pageAliases = new Map();
     tagPages = new Map();
+    settings = normalizeSettings();
 
     tagPage(tag) {
         return Array.from(this.tagPages.get(Tag.canonical(tag)) || "")[0]
@@ -49,7 +53,10 @@ export default class TagWrangler extends Plugin {
         app.workspace.trigger("tag-page:did-create", tp_evt);
     }
 
-    onload(){
+    async onload(){
+        await this.loadSettings();
+        this.addSettingTab(new TagWranglerSettingTab(this.app, this));
+
         this.registerEvent(
             app.workspace.on("editor-menu", (menu, editor) => {
                 const token = editor.getClickableTokenAt(editor.getCursor());
@@ -168,10 +175,13 @@ export default class TagWrangler extends Plugin {
         this.register(around(metaCache, {
             getTags(old) {
                 return function getTags() {
-                    const tags = old.call(this);
-                    const names = new Set(Object.keys(tags).map(t => t.toLowerCase()));
-                    for (const t of plugin.tagPages.keys()) {
-                        if (!names.has(t)) tags[plugin.tagPages.get(t).tag] = 0;
+                    const scopedTags = buildScopedTags(plugin.app, plugin.settings, plugin.tagPages);
+                    const tags = scopedTags || old.call(this);
+                    if (!scopedTags) {
+                        const names = new Set(Object.keys(tags).map(t => t.toLowerCase()));
+                        for (const t of plugin.tagPages.keys()) {
+                            if (!names.has(t)) tags[plugin.tagPages.get(t).tag] = 0;
+                        }
                     }
                     return tags;
                 }
@@ -300,6 +310,18 @@ export default class TagWrangler extends Plugin {
     async rename(tagName, toName=tagName) {
         try { await renameTag(this.app, tagName, toName); }
         catch (e) { console.error(e); new Notice("error: " + e); }
+    }
+
+    async loadSettings() {
+        this.settings = normalizeSettings(await this.loadData());
+    }
+
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
+
+    refreshTagsView() {
+        this.app.workspace.getLeavesOfType("tag").forEach(leaf => {leaf?.view?.requestUpdateTags?.()});
     }
 
 }

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,203 @@
+import {parseFrontMatterTags} from "obsidian";
+import {Tag} from "./Tag";
+
+export const DEFAULT_SETTINGS = {
+    scopedTags: {
+        enabled: false,
+        tagRules: [],
+        fileRules: []
+    }
+};
+
+export function normalizeSettings(data = {}) {
+    data = data || {};
+    const scopedTags = data.scopedTags || {};
+    return {
+        ...DEFAULT_SETTINGS,
+        ...data,
+        scopedTags: {
+            enabled: !!scopedTags.enabled,
+            tagRules: normalizeRules(scopedTags.tagRules),
+            fileRules: normalizeRules(scopedTags.fileRules, normalizeFileRule)
+        }
+    };
+}
+
+function normalizeRules(rules, normalize = normalizeRule) {
+    return Array.isArray(rules) ? rules.map(normalize).filter(Boolean) : [];
+}
+
+function normalizeRule(rule) {
+    if (!rule) return;
+    return {
+        enabled: rule.enabled !== false,
+        pattern: String(rule.pattern || "").trim(),
+        note: String(rule.note || "")
+    };
+}
+
+function normalizeFileRule(rule) {
+    const normalized = normalizeRule(rule);
+    if (!normalized) return;
+    normalized.mode = rule.mode === "exclude" ? "exclude" : "include";
+    return normalized;
+}
+
+export function buildScopedTags(app, settings, tagPages) {
+    const scopedTags = settings?.scopedTags;
+    if (!scopedTags?.enabled) return;
+    if (!enabledRules(scopedTags.tagRules).length && !enabledRules(scopedTags.fileRules).length) return;
+
+    return collectTags(app, tagPages, {
+        tagRules: scopedTags.tagRules,
+        fileRules: scopedTags.fileRules
+    });
+}
+
+export function getScopeStats(app, settings, tagPages) {
+    const allTags = collectTags(app, tagPages);
+    const scopedTags = settings.scopedTags.enabled
+        ? collectTags(app, tagPages, settings.scopedTags)
+        : allTags;
+    const files = app.metadataCache.getCachedFiles();
+
+    return {
+        totalTags: Object.keys(allTags).length,
+        visibleTags: Object.keys(scopedTags).length,
+        hiddenTags: Math.max(0, Object.keys(allTags).length - Object.keys(scopedTags).length),
+        totalFiles: files.length,
+        includedFiles: settings.scopedTags.enabled
+            ? files.filter(path => fileIncluded(path, settings.scopedTags.fileRules)).length
+            : files.length
+    };
+}
+
+export function countTagRuleMatches(app, tagPages, rule) {
+    if (!rule?.pattern) return 0;
+    return Object.keys(collectTags(app, tagPages))
+        .filter(tag => tagMatchesPattern(tag, rule.pattern))
+        .length;
+}
+
+export function countFileRuleMatches(app, rule) {
+    if (!rule?.pattern) return 0;
+    return app.metadataCache.getCachedFiles()
+        .filter(path => pathMatchesPattern(path, rule.pattern))
+        .length;
+}
+
+function collectTags(app, tagPages, scope = {}) {
+    const result = Object.create(null);
+    const displayNames = new Map();
+    const tagRules = enabledRules(scope.tagRules);
+    const fileRules = scope.fileRules || [];
+
+    function addTag(tag, count = 1) {
+        if (!tag || typeof tag !== "string") return;
+        tag = Tag.toTag(tag);
+        if (!Tag.isTag(tag)) return;
+        if (tagRules.length && !tagRules.some(rule => tagMatchesPattern(tag, rule.pattern))) return;
+
+        const canonical = Tag.canonical(tag);
+        let displayName = displayNames.get(canonical);
+        if (!displayName) {
+            displayName = tag;
+            displayNames.set(canonical, displayName);
+            result[displayName] = 0;
+        }
+        result[displayName] += count;
+    }
+
+    for (const filename of app.metadataCache.getCachedFiles()) {
+        if (!fileIncluded(filename, fileRules)) continue;
+
+        const cache = app.metadataCache.getCache(filename);
+        for (const item of cache?.tags || []) addTag(item.tag);
+        for (const tag of parseFrontMatterTags(cache?.frontmatter) || []) addTag(tag);
+    }
+
+    for (const [canonical, files] of tagPages || []) {
+        if (fileRules.length && !Array.from(files).some(file => fileIncluded(file?.path, fileRules))) continue;
+        const tag = files.tag || canonical;
+        if (tagRules.length && !tagRules.some(rule => tagMatchesPattern(tag, rule.pattern))) continue;
+        if (!displayNames.has(canonical)) result[tag] = 0;
+    }
+
+    return result;
+}
+
+function enabledRules(rules) {
+    return (rules || []).filter(rule => rule.enabled !== false && rule.pattern);
+}
+
+function fileIncluded(path, rules = []) {
+    path = normalizePath(path);
+    const enabledFileRules = enabledRules(rules);
+    const includeRules = enabledFileRules.filter(rule => rule.mode !== "exclude");
+    const excludeRules = enabledFileRules.filter(rule => rule.mode === "exclude");
+
+    const included = includeRules.length
+        ? includeRules.some(rule => pathMatchesPattern(path, rule.pattern))
+        : true;
+
+    return included && !excludeRules.some(rule => pathMatchesPattern(path, rule.pattern));
+}
+
+export function tagMatchesPattern(tag, pattern) {
+    tag = Tag.toTag(String(tag || "").trim()).toLowerCase();
+    pattern = Tag.toTag(String(pattern || "").trim()).toLowerCase();
+    if (!pattern || pattern === "#") return false;
+
+    if (pattern.endsWith("/*")) {
+        const prefix = pattern.slice(0, -1);
+        return tag.startsWith(prefix);
+    }
+
+    if (hasWildcard(pattern)) return globToRegExp(pattern, false).test(tag);
+    return tag === pattern;
+}
+
+export function pathMatchesPattern(path, pattern) {
+    path = normalizePath(path);
+    pattern = normalizePath(pattern);
+    if (!pattern) return false;
+
+    if (hasWildcard(pattern)) return globToRegExp(pattern, true).test(path);
+    if (pattern.endsWith("/")) return path.startsWith(pattern);
+    return path === pattern || path.startsWith(pattern + "/");
+}
+
+function normalizePath(path) {
+    return String(path || "")
+        .replace(/\\/g, "/")
+        .replace(/^\/+/, "")
+        .trim();
+}
+
+function hasWildcard(pattern) {
+    return /[*?]/.test(pattern);
+}
+
+function globToRegExp(pattern, pathMode) {
+    let re = "^";
+    for (let i = 0; i < pattern.length; i++) {
+        const ch = pattern[i];
+        if (ch === "*") {
+            if (pattern[i + 1] === "*") {
+                re += ".*";
+                i++;
+            } else {
+                re += pathMode ? "[^/]*" : ".*";
+            }
+        } else if (ch === "?") {
+            re += pathMode ? "[^/]" : ".";
+        } else {
+            re += escapeRegExp(ch);
+        }
+    }
+    return new RegExp(re + "$");
+}
+
+function escapeRegExp(text) {
+    return text.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
+}

--- a/src/scope.js
+++ b/src/scope.js
@@ -72,6 +72,93 @@ export function getScopeStats(app, settings, tagPages) {
     };
 }
 
+export async function buildScopeReport(app, settings, tagPages, isCurrent = () => true) {
+    const files = app.metadataCache.getCachedFiles();
+    const allTags = Object.create(null);
+    const scopedTags = Object.create(null);
+    const allDisplayNames = new Map();
+    const scopedDisplayNames = new Map();
+    const scopedTagRules = enabledRules(settings.scopedTags.tagRules);
+    const scopedFileRules = settings.scopedTags.fileRules || [];
+    const scopedFileMatcher = compileFileScopeMatcher(scopedFileRules);
+    const fileRuleMatchers = settings.scopedTags.fileRules.map(rule => (
+        rule.pattern ? compilePathMatcher(rule.pattern) : undefined
+    ));
+    const fileRuleMatches = settings.scopedTags.fileRules.map(() => 0);
+    let includedFiles = 0;
+
+    await yieldToUI();
+
+    function addTag(result, displayNames, tag, tagRules = []) {
+        if (!tag || typeof tag !== "string") return;
+        tag = Tag.toTag(tag);
+        if (!Tag.isTag(tag)) return;
+        if (tagRules.length && !tagRules.some(rule => tagMatchesPattern(tag, rule.pattern))) return;
+
+        const canonical = Tag.canonical(tag);
+        let displayName = displayNames.get(canonical);
+        if (!displayName) {
+            displayName = tag;
+            displayNames.set(canonical, displayName);
+            result[displayName] = 0;
+        }
+        result[displayName]++;
+    }
+
+    for (let index = 0; index < files.length; index++) {
+        if (!isCurrent()) return;
+
+        const filename = files[index];
+        const normalizedFilename = normalizePath(filename);
+        fileRuleMatchers.forEach((matches, ruleIndex) => {
+            if (matches?.(normalizedFilename)) fileRuleMatches[ruleIndex]++;
+        });
+
+        const cache = app.metadataCache.getCache(filename);
+        const bodyTags = cache?.tags || [];
+        const frontmatterTags = parseFrontMatterTags(cache?.frontmatter) || [];
+        const included = scopedFileMatcher(normalizedFilename);
+
+        if (included) includedFiles++;
+
+        for (const item of bodyTags) {
+            addTag(allTags, allDisplayNames, item.tag);
+            if (included) addTag(scopedTags, scopedDisplayNames, item.tag, scopedTagRules);
+        }
+        for (const tag of frontmatterTags) {
+            addTag(allTags, allDisplayNames, tag);
+            if (included) addTag(scopedTags, scopedDisplayNames, tag, scopedTagRules);
+        }
+
+        if (index && index % 1000 === 0) await yieldToUI();
+    }
+
+    for (const [canonical, pages] of tagPages || []) {
+        addTag(allTags, allDisplayNames, pages.tag || canonical, []);
+        if (fileIncludedTagPage(pages, scopedFileRules)) {
+            addTag(scopedTags, scopedDisplayNames, pages.tag || canonical, scopedTagRules);
+        }
+    }
+
+    const scopeHasRules = scopedTagRules.length || enabledRules(scopedFileRules).length;
+    const visibleTags = settings.scopedTags.enabled && scopeHasRules ? scopedTags : allTags;
+    const allTagNames = Object.keys(allTags);
+
+    return {
+        stats: {
+            totalTags: allTagNames.length,
+            visibleTags: Object.keys(visibleTags).length,
+            hiddenTags: Math.max(0, allTagNames.length - Object.keys(visibleTags).length),
+            totalFiles: files.length,
+            includedFiles: settings.scopedTags.enabled ? includedFiles : files.length
+        },
+        tagRuleMatches: settings.scopedTags.tagRules.map(rule => (
+            rule.pattern ? allTagNames.filter(tag => tagMatchesPattern(tag, rule.pattern)).length : 0
+        )),
+        fileRuleMatches
+    };
+}
+
 export function countTagRuleMatches(app, tagPages, rule) {
     if (!rule?.pattern) return 0;
     return Object.keys(collectTags(app, tagPages))
@@ -126,21 +213,42 @@ function collectTags(app, tagPages, scope = {}) {
     return result;
 }
 
+function fileIncludedTagPage(files, fileRules) {
+    if (!fileRules?.length) return true;
+    const matches = compileFileScopeMatcher(fileRules);
+    return Array.from(files).some(file => matches(normalizePath(file?.path)));
+}
+
+function yieldToUI() {
+    return new Promise(resolve => activeWindow.setTimeout(resolve, 0));
+}
+
 function enabledRules(rules) {
     return (rules || []).filter(rule => rule.enabled !== false && rule.pattern);
 }
 
 function fileIncluded(path, rules = []) {
     path = normalizePath(path);
+    return compileFileScopeMatcher(rules)(path);
+}
+
+function compileFileScopeMatcher(rules = []) {
     const enabledFileRules = enabledRules(rules);
-    const includeRules = enabledFileRules.filter(rule => rule.mode !== "exclude");
-    const excludeRules = enabledFileRules.filter(rule => rule.mode === "exclude");
+    const includeRules = enabledFileRules
+        .filter(rule => rule.mode !== "exclude")
+        .map(rule => compilePathMatcher(rule.pattern));
+    const excludeRules = enabledFileRules
+        .filter(rule => rule.mode === "exclude")
+        .map(rule => compilePathMatcher(rule.pattern));
 
-    const included = includeRules.length
-        ? includeRules.some(rule => pathMatchesPattern(path, rule.pattern))
-        : true;
+    return path => {
+        path = normalizePath(path);
+        const included = includeRules.length
+            ? includeRules.some(matches => matches(path))
+            : true;
 
-    return included && !excludeRules.some(rule => pathMatchesPattern(path, rule.pattern));
+        return included && !excludeRules.some(matches => matches(path));
+    };
 }
 
 export function tagMatchesPattern(tag, pattern) {
@@ -159,12 +267,20 @@ export function tagMatchesPattern(tag, pattern) {
 
 export function pathMatchesPattern(path, pattern) {
     path = normalizePath(path);
-    pattern = normalizePath(pattern);
-    if (!pattern) return false;
+    return compilePathMatcher(pattern)(path);
+}
 
-    if (hasWildcard(pattern)) return globToRegExp(pattern, true).test(path);
-    if (pattern.endsWith("/")) return path.startsWith(pattern);
-    return path === pattern || path.startsWith(pattern + "/");
+function compilePathMatcher(pattern) {
+    pattern = normalizePath(pattern);
+    if (!pattern) return () => false;
+
+    if (hasWildcard(pattern)) {
+        const wildcardPattern = pattern.endsWith("/") ? pattern + "**" : pattern;
+        const regex = globToRegExp(wildcardPattern, true);
+        return path => regex.test(path);
+    }
+    if (pattern.endsWith("/")) return path => path.startsWith(pattern);
+    return path => path === pattern || path.startsWith(pattern + "/");
 }
 
 function normalizePath(path) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,189 @@
+import {PluginSettingTab, Setting} from "obsidian";
+import {countFileRuleMatches, countTagRuleMatches, getScopeStats} from "./scope";
+
+export class TagWranglerSettingTab extends PluginSettingTab {
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+
+    display() {
+        const {containerEl} = this;
+        containerEl.empty();
+        containerEl.addClass("tag-wrangler-settings");
+
+        containerEl.createEl("h2", {text: "Tag Wrangler"});
+
+        const stats = getScopeStats(this.app, this.plugin.settings, this.plugin.tagPages);
+        new Setting(containerEl)
+            .setName("Scoped tag list")
+            .setDesc(
+                "Filter the Tags view to tags and files that match the rules below. Files remain searchable and linkable in Obsidian."
+            )
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.scopedTags.enabled)
+                .onChange(value => this.update(async () => {
+                    this.plugin.settings.scopedTags.enabled = value;
+                }))
+            );
+
+        containerEl.createDiv({
+            cls: "tag-wrangler-scope-summary",
+            text: `Visible tags: ${stats.visibleTags} / ${stats.totalTags}. Included files: ${stats.includedFiles} / ${stats.totalFiles}.`
+        });
+
+        this.renderTagRules(containerEl);
+        this.renderFileRules(containerEl);
+    }
+
+    renderTagRules(containerEl) {
+        const section = this.createSection(containerEl, "Tag allow list", "Only matching tags are shown when scoped tags are enabled.");
+        new Setting(section.headerEl)
+            .addButton(button => button
+                .setButtonText("New")
+                .onClick(() => this.update(async () => {
+                    this.plugin.settings.scopedTags.tagRules.push({enabled: true, pattern: "", note: ""});
+                }))
+            );
+
+        const grid = section.bodyEl.createDiv({cls: "tag-wrangler-rule-grid tag-wrangler-tag-rules"});
+        this.addHeader(grid, ["Enabled", "Pattern", "Matches", "Note", ""]);
+
+        const rules = this.plugin.settings.scopedTags.tagRules;
+        if (!rules.length) {
+            this.addEmptyState(grid, "No tag rules. Add a rule such as #area/* or #review.");
+            return;
+        }
+
+        rules.forEach((rule, index) => {
+            this.addToggleCell(grid, rule.enabled, value => this.update(async () => {
+                rule.enabled = value;
+            }));
+            this.addTextCell(grid, rule.pattern, "#area/*", value => this.update(async () => {
+                rule.pattern = value;
+            }));
+            grid.createDiv({
+                cls: "tag-wrangler-rule-count",
+                text: String(countTagRuleMatches(this.app, this.plugin.tagPages, rule))
+            });
+            this.addTextCell(grid, rule.note, "Optional note", value => this.update(async () => {
+                rule.note = value;
+            }));
+            this.addDeleteButton(grid, () => this.update(async () => {
+                rules.splice(index, 1);
+            }));
+        });
+    }
+
+    renderFileRules(containerEl) {
+        const section = this.createSection(containerEl, "File scope", "Include or exclude folders and files from tag counting only.");
+        new Setting(section.headerEl)
+            .addButton(button => button
+                .setButtonText("New include")
+                .onClick(() => this.update(async () => {
+                    this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "include", pattern: "", note: ""});
+                }))
+            )
+            .addButton(button => button
+                .setButtonText("New exclude")
+                .onClick(() => this.update(async () => {
+                    this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "exclude", pattern: "", note: ""});
+                }))
+            );
+
+        const grid = section.bodyEl.createDiv({cls: "tag-wrangler-rule-grid tag-wrangler-file-rules"});
+        this.addHeader(grid, ["Enabled", "Mode", "Path pattern", "Files", "Note", ""]);
+
+        const rules = this.plugin.settings.scopedTags.fileRules;
+        if (!rules.length) {
+            this.addEmptyState(grid, "No file rules. Without include rules, all files are included unless excluded.");
+            return;
+        }
+
+        rules.forEach((rule, index) => {
+            this.addToggleCell(grid, rule.enabled, value => this.update(async () => {
+                rule.enabled = value;
+            }));
+            this.addModeCell(grid, rule.mode, value => this.update(async () => {
+                rule.mode = value;
+            }));
+            this.addTextCell(grid, rule.pattern, "20-Projects/RedNotes/", value => this.update(async () => {
+                rule.pattern = value;
+            }));
+            grid.createDiv({
+                cls: "tag-wrangler-rule-count",
+                text: String(countFileRuleMatches(this.app, rule))
+            });
+            this.addTextCell(grid, rule.note, "Optional note", value => this.update(async () => {
+                rule.note = value;
+            }));
+            this.addDeleteButton(grid, () => this.update(async () => {
+                rules.splice(index, 1);
+            }));
+        });
+    }
+
+    createSection(containerEl, title, description) {
+        const sectionEl = containerEl.createDiv({cls: "tag-wrangler-rule-section"});
+        const headerEl = sectionEl.createDiv({cls: "tag-wrangler-rule-section-header"});
+        const titleEl = headerEl.createDiv();
+        titleEl.createEl("h3", {text: title});
+        titleEl.createDiv({cls: "setting-item-description", text: description});
+        const bodyEl = sectionEl.createDiv({cls: "tag-wrangler-rule-box"});
+        return {sectionEl, headerEl, bodyEl};
+    }
+
+    addHeader(grid, labels) {
+        for (const label of labels) grid.createDiv({cls: "tag-wrangler-rule-header", text: label});
+    }
+
+    addEmptyState(grid, text) {
+        grid.createDiv({cls: "tag-wrangler-rule-empty", text});
+    }
+
+    addToggleCell(grid, value, onChange) {
+        const cell = grid.createDiv({cls: "tag-wrangler-rule-cell"});
+        const input = cell.createEl("input", {attr: {type: "checkbox"}});
+        input.checked = value !== false;
+        input.addEventListener("change", () => onChange(input.checked));
+    }
+
+    addModeCell(grid, value, onChange) {
+        const cell = grid.createDiv({cls: "tag-wrangler-rule-cell"});
+        const select = cell.createEl("select");
+        select.createEl("option", {text: "include", attr: {value: "include"}});
+        select.createEl("option", {text: "exclude", attr: {value: "exclude"}});
+        select.value = value === "exclude" ? "exclude" : "include";
+        select.addEventListener("change", () => onChange(select.value));
+    }
+
+    addTextCell(grid, value, placeholder, onChange) {
+        const cell = grid.createDiv({cls: "tag-wrangler-rule-cell"});
+        const input = cell.createEl("input", {attr: {type: "text", placeholder}});
+        input.value = value || "";
+        const save = () => {
+            if (input.value !== value) onChange(input.value.trim());
+        };
+        input.addEventListener("blur", save);
+        input.addEventListener("keydown", event => {
+            if (event.key === "Enter") {
+                save();
+                input.blur();
+            }
+        });
+    }
+
+    addDeleteButton(grid, onClick) {
+        const cell = grid.createDiv({cls: "tag-wrangler-rule-cell"});
+        cell.createEl("button", {text: "Delete"}, button => {
+            button.addEventListener("click", onClick);
+        });
+    }
+
+    async update(mutator) {
+        await mutator();
+        await this.plugin.saveSettings();
+        this.plugin.refreshTagsView();
+        this.display();
+    }
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,7 +1,9 @@
 import {PluginSettingTab, Setting} from "obsidian";
-import {countFileRuleMatches, countTagRuleMatches, getScopeStats} from "./scope";
+import {buildScopeReport} from "./scope";
 
 export class TagWranglerSettingTab extends PluginSettingTab {
+    reportGeneration = 0;
+
     constructor(app, plugin) {
         super(app, plugin);
         this.plugin = plugin;
@@ -14,7 +16,6 @@ export class TagWranglerSettingTab extends PluginSettingTab {
 
         containerEl.createEl("h2", {text: "Tag Wrangler"});
 
-        const stats = getScopeStats(this.app, this.plugin.settings, this.plugin.tagPages);
         new Setting(containerEl)
             .setName("Scoped tag list")
             .setDesc(
@@ -27,24 +28,30 @@ export class TagWranglerSettingTab extends PluginSettingTab {
                 }))
             );
 
-        containerEl.createDiv({
-            cls: "tag-wrangler-scope-summary",
-            text: `Visible tags: ${stats.visibleTags} / ${stats.totalTags}. Included files: ${stats.includedFiles} / ${stats.totalFiles}.`
+        const summaryRowEl = containerEl.createDiv({cls: "tag-wrangler-scope-summary-row"});
+        const summaryEl = summaryRowEl.createDiv({
+            cls: "tag-wrangler-scope-summary-text",
+            text: "Calculating tag scope..."
         });
+        const refreshButton = summaryRowEl.createEl("button", {text: "Refresh", cls: "tag-wrangler-refresh-button"});
 
-        this.renderTagRules(containerEl);
-        this.renderFileRules(containerEl);
+        const tagCountEls = this.renderTagRules(containerEl);
+        const fileCountEls = this.renderFileRules(containerEl);
+        refreshButton.addEventListener("click", () => {
+            this.loadReport(summaryEl, tagCountEls, fileCountEls, refreshButton);
+        });
+        this.loadReport(summaryEl, tagCountEls, fileCountEls, refreshButton);
+    }
+
+    hide() {
+        this.reportGeneration++;
     }
 
     renderTagRules(containerEl) {
         const section = this.createSection(containerEl, "Tag allow list", "Only matching tags are shown when scoped tags are enabled.");
-        new Setting(section.headerEl)
-            .addButton(button => button
-                .setButtonText("New")
-                .onClick(() => this.update(async () => {
-                    this.plugin.settings.scopedTags.tagRules.push({enabled: true, pattern: "", note: ""});
-                }))
-            );
+        this.addSectionButton(section.actionsEl, "New", () => this.update(async () => {
+            this.plugin.settings.scopedTags.tagRules.push({enabled: true, pattern: "", note: ""});
+        }));
 
         const grid = section.bodyEl.createDiv({cls: "tag-wrangler-rule-grid tag-wrangler-tag-rules"});
         this.addHeader(grid, ["Enabled", "Pattern", "Matches", "Note", ""]);
@@ -52,19 +59,19 @@ export class TagWranglerSettingTab extends PluginSettingTab {
         const rules = this.plugin.settings.scopedTags.tagRules;
         if (!rules.length) {
             this.addEmptyState(grid, "No tag rules. Add a rule such as #area/* or #review.");
-            return;
+            return [];
         }
 
-        rules.forEach((rule, index) => {
+        return rules.map((rule, index) => {
             this.addToggleCell(grid, rule.enabled, value => this.update(async () => {
                 rule.enabled = value;
             }));
             this.addTextCell(grid, rule.pattern, "#area/*", value => this.update(async () => {
                 rule.pattern = value;
             }));
-            grid.createDiv({
+            const countEl = grid.createDiv({
                 cls: "tag-wrangler-rule-count",
-                text: String(countTagRuleMatches(this.app, this.plugin.tagPages, rule))
+                text: rule.pattern ? "..." : "0"
             });
             this.addTextCell(grid, rule.note, "Optional note", value => this.update(async () => {
                 rule.note = value;
@@ -72,24 +79,18 @@ export class TagWranglerSettingTab extends PluginSettingTab {
             this.addDeleteButton(grid, () => this.update(async () => {
                 rules.splice(index, 1);
             }));
+            return countEl;
         });
     }
 
     renderFileRules(containerEl) {
         const section = this.createSection(containerEl, "File scope", "Include or exclude folders and files from tag counting only.");
-        new Setting(section.headerEl)
-            .addButton(button => button
-                .setButtonText("New include")
-                .onClick(() => this.update(async () => {
-                    this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "include", pattern: "", note: ""});
-                }))
-            )
-            .addButton(button => button
-                .setButtonText("New exclude")
-                .onClick(() => this.update(async () => {
-                    this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "exclude", pattern: "", note: ""});
-                }))
-            );
+        this.addSectionButton(section.actionsEl, "New include", () => this.update(async () => {
+            this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "include", pattern: "", note: ""});
+        }));
+        this.addSectionButton(section.actionsEl, "New exclude", () => this.update(async () => {
+            this.plugin.settings.scopedTags.fileRules.push({enabled: true, mode: "exclude", pattern: "", note: ""});
+        }));
 
         const grid = section.bodyEl.createDiv({cls: "tag-wrangler-rule-grid tag-wrangler-file-rules"});
         this.addHeader(grid, ["Enabled", "Mode", "Path pattern", "Files", "Note", ""]);
@@ -97,10 +98,10 @@ export class TagWranglerSettingTab extends PluginSettingTab {
         const rules = this.plugin.settings.scopedTags.fileRules;
         if (!rules.length) {
             this.addEmptyState(grid, "No file rules. Without include rules, all files are included unless excluded.");
-            return;
+            return [];
         }
 
-        rules.forEach((rule, index) => {
+        return rules.map((rule, index) => {
             this.addToggleCell(grid, rule.enabled, value => this.update(async () => {
                 rule.enabled = value;
             }));
@@ -110,9 +111,9 @@ export class TagWranglerSettingTab extends PluginSettingTab {
             this.addTextCell(grid, rule.pattern, "20-Projects/RedNotes/", value => this.update(async () => {
                 rule.pattern = value;
             }));
-            grid.createDiv({
+            const countEl = grid.createDiv({
                 cls: "tag-wrangler-rule-count",
-                text: String(countFileRuleMatches(this.app, rule))
+                text: rule.pattern ? "..." : "0"
             });
             this.addTextCell(grid, rule.note, "Optional note", value => this.update(async () => {
                 rule.note = value;
@@ -120,6 +121,7 @@ export class TagWranglerSettingTab extends PluginSettingTab {
             this.addDeleteButton(grid, () => this.update(async () => {
                 rules.splice(index, 1);
             }));
+            return countEl;
         });
     }
 
@@ -129,8 +131,15 @@ export class TagWranglerSettingTab extends PluginSettingTab {
         const titleEl = headerEl.createDiv();
         titleEl.createEl("h3", {text: title});
         titleEl.createDiv({cls: "setting-item-description", text: description});
+        const actionsEl = headerEl.createDiv({cls: "tag-wrangler-rule-section-actions"});
         const bodyEl = sectionEl.createDiv({cls: "tag-wrangler-rule-box"});
-        return {sectionEl, headerEl, bodyEl};
+        return {sectionEl, headerEl, actionsEl, bodyEl};
+    }
+
+    addSectionButton(containerEl, text, onClick) {
+        containerEl.createEl("button", {text}, button => {
+            button.addEventListener("click", onClick);
+        });
     }
 
     addHeader(grid, labels) {
@@ -185,5 +194,23 @@ export class TagWranglerSettingTab extends PluginSettingTab {
         await this.plugin.saveSettings();
         this.plugin.refreshTagsView();
         this.display();
+    }
+
+    async loadReport(summaryEl, tagCountEls, fileCountEls, refreshButton) {
+        const generation = ++this.reportGeneration;
+        const isCurrent = () => generation === this.reportGeneration;
+        summaryEl.setText("Calculating tag scope...");
+        tagCountEls.forEach(el => el.setText("..."));
+        fileCountEls.forEach(el => el.setText("..."));
+        if (refreshButton) refreshButton.disabled = true;
+
+        const report = await buildScopeReport(this.app, this.plugin.settings, this.plugin.tagPages, isCurrent);
+        if (!report || !isCurrent()) return;
+
+        const {stats} = report;
+        summaryEl.setText(`Visible tags: ${stats.visibleTags} / ${stats.totalTags}. Included files: ${stats.includedFiles} / ${stats.totalFiles}.`);
+        tagCountEls.forEach((el, index) => el.setText(String(report.tagRuleMatches[index] || 0)));
+        fileCountEls.forEach((el, index) => el.setText(String(report.fileRuleMatches[index] || 0)));
+        if (refreshButton) refreshButton.disabled = false;
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,83 @@
+.tag-wrangler-settings {
+  .tag-wrangler-scope-summary {
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .tag-wrangler-rule-section {
+    margin-top: 1.5rem;
+  }
+
+  .tag-wrangler-rule-section-header {
+    align-items: end;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+
+    h3 {
+      margin-bottom: 0.25rem;
+    }
+
+    .setting-item {
+      border: 0;
+      padding: 0;
+    }
+  }
+
+  .tag-wrangler-rule-box {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    margin-top: 0.75rem;
+    max-height: 16rem;
+    overflow: auto;
+  }
+
+  .tag-wrangler-rule-grid {
+    display: grid;
+    min-width: 42rem;
+  }
+
+  .tag-wrangler-tag-rules {
+    grid-template-columns: 5rem minmax(12rem, 1.1fr) 5rem minmax(12rem, 1fr) 5rem;
+  }
+
+  .tag-wrangler-file-rules {
+    grid-template-columns: 5rem 7rem minmax(14rem, 1.2fr) 5rem minmax(12rem, 1fr) 5rem;
+  }
+
+  .tag-wrangler-rule-header,
+  .tag-wrangler-rule-cell,
+  .tag-wrangler-rule-count,
+  .tag-wrangler-rule-empty {
+    align-items: center;
+    border-bottom: 1px solid var(--background-modifier-border);
+    display: flex;
+    min-height: 2.5rem;
+    padding: 0.35rem 0.5rem;
+  }
+
+  .tag-wrangler-rule-header {
+    background: var(--background-secondary);
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+    font-weight: var(--font-semibold);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .tag-wrangler-rule-cell input[type="text"],
+  .tag-wrangler-rule-cell select {
+    width: 100%;
+  }
+
+  .tag-wrangler-rule-count {
+    color: var(--text-muted);
+    justify-content: end;
+  }
+
+  .tag-wrangler-rule-empty {
+    color: var(--text-muted);
+    grid-column: 1 / -1;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,18 @@
 .tag-wrangler-settings {
-  .tag-wrangler-scope-summary {
-    color: var(--text-muted);
+  .tag-wrangler-scope-summary-row {
+    align-items: center;
+    display: flex;
+    gap: 0.75rem;
     margin: 0 0 1rem;
+  }
+
+  .tag-wrangler-scope-summary-text {
+    color: var(--text-muted);
+    font-size: var(--font-ui-medium);
+  }
+
+  .tag-wrangler-refresh-button {
+    flex: 0 0 auto;
   }
 
   .tag-wrangler-rule-section {
@@ -17,11 +28,12 @@
     h3 {
       margin-bottom: 0.25rem;
     }
+  }
 
-    .setting-item {
-      border: 0;
-      padding: 0;
-    }
+  .tag-wrangler-rule-section-actions {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 0.5rem;
   }
 
   .tag-wrangler-rule-box {


### PR DESCRIPTION
Fixes #162.

## Summary
- Add an optional settings tab for a scoped tag list.
- Support tag allow rules such as `#review`, `#area/*`, and simple wildcards.
- Support file scope include/exclude rules so generated or dependency folders can be hidden from the Tags view without hiding files from Obsidian search, links, or backlinks.
- Compute settings-page statistics asynchronously and add a Refresh button so large vaults do not block when opening the settings tab.

## Testing
- `pnpm build`
- `pnpm test` is not available in this repository (`ERR_PNPM_NO_SCRIPT`).