### PR TITLE
feat: "Remove #tag from all notes" context-menu action

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,18 @@
   "name": "tag-wrangler",
   "scripts": {
     "dev": "node ophidian.config.mjs dev",
-    "build": "node ophidian.config.mjs production"
+    "build": "node ophidian.config.mjs production",
+    "test": "vitest run"
   },
   "license": "ISC",
   "packageManager": "pnpm@7.33.6",
   "devDependencies": {
-    "monkey-around": "^3",
-    "obsidian": "1.3.5",
     "@ophidian/build": "^1.2",
     "@ophidian/core": "github:ophidian-lib/core",
+    "monkey-around": "^3",
+    "obsidian": "1.3.5",
     "uneventful": "^0.0.10",
+    "vitest": "^4.1.10",
     "yaml": "2.0.0-10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,16 @@ specifiers:
   monkey-around: ^3
   obsidian: 1.3.5
   uneventful: ^0.0.10
+  vitest: ^4.1.10
   yaml: 2.0.0-10
 
 devDependencies:
   '@ophidian/build': 1.2.1
-  '@ophidian/core': github.com/ophidian-lib/core/46b123f1010df0d1775d98947e73bfecaadaa428_uneventful@0.0.10
+  '@ophidian/core': github.com/ophidian-lib/core/81d7d1463c75f7b2feebfc56adee430dc7d700f1_w62i6d4ss6wczex7peftvtgv2a
   monkey-around: 3.0.0
   obsidian: 1.3.5
   uneventful: 0.0.10
+  vitest: 4.1.10_yaml@2.0.0-10
   yaml: 2.0.0-10
 
 packages:
@@ -24,6 +26,31 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.1
     dev: true
+
+  /@emnapi/core/1.11.1:
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    dev: true
+    optional: true
+
+  /@emnapi/runtime/1.11.1:
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+    optional: true
+
+  /@emnapi/wasi-threads/1.2.2:
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+    optional: true
 
   /@esbuild/android-arm/0.17.6:
     resolution: {integrity: sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==}
@@ -223,6 +250,23 @@ packages:
     dev: true
     optional: true
 
+  /@jridgewell/sourcemap-codec/1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
+  /@napi-rs/wasm-runtime/1.1.6_sbf6ynk3btphwcst4sq4arezsy:
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    requiresBuild: true
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    dev: true
+    optional: true
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -257,20 +301,255 @@ packages:
       sass: 1.47.0
     dev: true
 
+  /@oxc-project/types/0.139.0:
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+    dev: true
+
+  /@rolldown/binding-android-arm64/1.1.5:
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-darwin-arm64/1.1.5:
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-darwin-x64/1.1.5:
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-freebsd-x64/1.1.5:
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-arm-gnueabihf/1.1.5:
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-arm64-gnu/1.1.5:
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-arm64-musl/1.1.5:
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-ppc64-gnu/1.1.5:
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-s390x-gnu/1.1.5:
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-x64-gnu/1.1.5:
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-linux-x64-musl/1.1.5:
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-openharmony-arm64/1.1.5:
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-wasm32-wasi/1.1.5:
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6_sbf6ynk3btphwcst4sq4arezsy
+    dev: true
+    optional: true
+
+  /@rolldown/binding-win32-arm64-msvc/1.1.5:
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/binding-win32-x64-msvc/1.1.5:
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rolldown/pluginutils/1.0.1:
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+    dev: true
+
+  /@standard-schema/spec/1.1.0:
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+    dev: true
+
+  /@tybys/wasm-util/0.10.3:
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+    optional: true
+
+  /@types/chai/5.2.3:
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
   /@types/codemirror/5.60.8:
     resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
     dependencies:
       '@types/tern': 0.23.4
     dev: true
 
+  /@types/deep-eql/4.0.2:
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+    dev: true
+
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+    dev: true
+
+  /@types/estree/1.0.9:
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
     dev: true
 
   /@types/tern/0.23.4:
     resolution: {integrity: sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==}
     dependencies:
       '@types/estree': 0.0.51
+    dev: true
+
+  /@vitest/expect/4.1.10:
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/mocker/4.1.10_vite@8.1.4:
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 8.1.4_yaml@2.0.0-10
+    dev: true
+
+  /@vitest/pretty-format/4.1.10:
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+    dependencies:
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/runner/4.1.10:
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/snapshot/4.1.10:
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy/4.1.10:
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+    dev: true
+
+  /@vitest/utils/4.1.10:
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
     dev: true
 
   /ansi-styles/4.3.0:
@@ -310,6 +589,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /assertion-error/2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -336,6 +620,11 @@ packages:
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+    dev: true
+
+  /chai/6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
     dev: true
 
   /chalk/4.1.2:
@@ -376,6 +665,10 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /convert-source-map/2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    dev: true
+
   /copy-newer/2.1.2:
     resolution: {integrity: sha512-IDhyNGNvbSqwjQXjZ3tAzZNXRw0UmXa+TmTQmMJziikQ+sdsV9EkI6B2WZX1u9m3TKHayBCc2pGqXU/KlBqJdg==}
     engines: {node: '>=4'}
@@ -406,11 +699,20 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
+  /detect-libc/2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /es-module-lexer/2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
     dev: true
 
   /esbuild-plugin-copy/2.1.1_esbuild@0.17.6:
@@ -467,6 +769,17 @@ packages:
       '@esbuild/win32-x64': 0.17.6
     dev: true
 
+  /estree-walker/3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.9
+    dev: true
+
+  /expect-type/1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
     engines: {node: '>=8.6.0'}
@@ -482,6 +795,18 @@ packages:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
       reusify: 1.0.4
+    dev: true
+
+  /fdir/6.5.0_picomatch@4.0.5:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.5
     dev: true
 
   /fill-range/7.0.1:
@@ -525,6 +850,14 @@ packages:
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -666,6 +999,130 @@ packages:
       graceful-fs: 4.2.9
     dev: true
 
+  /lightningcss-android-arm64/1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-darwin-arm64/1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-darwin-x64/1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-freebsd-x64/1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm-gnueabihf/1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm64-gnu/1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm64-musl/1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-x64-gnu/1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-x64-musl/1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-win32-arm64-msvc/1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-win32-x64-msvc/1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss/1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    dev: true
+
+  /magic-string/0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
     dev: true
@@ -712,6 +1169,12 @@ packages:
     resolution: {integrity: sha512-jL6uY2lEAoaHxZep1cNRkCZjoIWY4g5VYCjriEWmcyHU7w8NU1+JH57xE251UVTohK0lCxMjv0ZV4ByDLIXEpw==}
     dev: true
 
+  /nanoid/3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -732,6 +1195,11 @@ packages:
       moment: 2.29.4
     dev: true
 
+  /obug/2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+    dev: true
+
   /once/1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
@@ -748,9 +1216,22 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe/2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
+  /picocolors/1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /picomatch/4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
     dev: true
 
   /pify/2.3.0:
@@ -768,6 +1249,15 @@ packages:
   /pinkie/2.0.4:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postcss/8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /process-nextick-args/2.0.1:
@@ -814,6 +1304,31 @@ packages:
       glob: 7.2.0
     dev: true
 
+  /rolldown/1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -834,6 +1349,10 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /siginfo/2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -844,9 +1363,22 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map-js/1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /stackback/0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env/4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
     dev: true
 
   /string_decoder/1.1.1:
@@ -860,6 +1392,28 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
+
+  /tinybench/2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinyexec/1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /tinyglobby/0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0_picomatch@4.0.5
+      picomatch: 4.0.5
+    dev: true
+
+  /tinyrainbow/3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /tmp/0.2.1:
@@ -880,6 +1434,12 @@ packages:
     resolution: {integrity: sha512-i5hrYhcDyrjl4tF2EvZnmL8VAMdMYnMFeX1bIF0ekn2gKgs76UhZcHt+hLIUKh0fIii+Ix6uUp5W6yYlU5+Z8A==}
     dev: true
 
+  /tslib/2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /uneventful/0.0.10:
     resolution: {integrity: sha512-uSgjcmhgH8tqwT8fe8iVIitUbfZfmha7Xxi2cu/ZpJsvl+iQtYfFPjF/tA/s+Co8pbIo08jZh70Kww9PraCSAg==}
     dev: true
@@ -893,6 +1453,143 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
+  /vite/8.1.4_yaml@2.0.0-10:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+      yaml: 2.0.0-10
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest/4.1.10_yaml@2.0.0-10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10_vite@8.1.4
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4_yaml@2.0.0-10
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /why-is-node-running/2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
@@ -902,14 +1599,15 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  github.com/ophidian-lib/core/46b123f1010df0d1775d98947e73bfecaadaa428_uneventful@0.0.10:
-    resolution: {tarball: https://codeload.github.com/ophidian-lib/core/tar.gz/46b123f1010df0d1775d98947e73bfecaadaa428}
-    id: github.com/ophidian-lib/core/46b123f1010df0d1775d98947e73bfecaadaa428
+  github.com/ophidian-lib/core/81d7d1463c75f7b2feebfc56adee430dc7d700f1_w62i6d4ss6wczex7peftvtgv2a:
+    resolution: {tarball: https://codeload.github.com/ophidian-lib/core/tar.gz/81d7d1463c75f7b2feebfc56adee430dc7d700f1}
+    id: github.com/ophidian-lib/core/81d7d1463c75f7b2feebfc56adee430dc7d700f1
     name: '@ophidian/core'
     version: 0.0.24
     prepare: true
     requiresBuild: true
     peerDependencies:
+      obsidian: 1.3.5
       uneventful: ^0.0.10
     dependencies:
       defaults: 2.0.2
@@ -918,7 +1616,4 @@ packages:
       obsidian: 1.3.5
       to-use: 0.3.3
       uneventful: 0.0.10
-    transitivePeerDependencies:
-      - '@codemirror/state'
-      - '@codemirror/view'
     dev: true

--- a/src/File.js
+++ b/src/File.js
@@ -1,6 +1,7 @@
 import { Notice } from "obsidian";
 import { CST, parseDocument } from "yaml";
 import { Replacement } from "./Tag";
+import { removeInlineTags, removeFromFrontMatter } from "./removal";
 
 export class File {
 
@@ -38,6 +39,41 @@ export class File {
         }
     }
 
+    /** @param {import("./Tag").Tag} tag */
+    async removed(tag) {
+        // Never let one note abort the whole bulk run: any failure (I/O, changed
+        // file, bad frontmatter) warns and skips that note, reported as "skipped".
+        try {
+            const file = this.app.vault.getAbstractFileByPath(this.filename);
+            const original = await this.app.vault.read(file);
+            let text;
+            try {
+                text = removeInlineTags(original, this.tagPositions);
+            } catch (e) {
+                return this.skip(e, `File ${this.filename} has changed`);
+            }
+            if (this.hasFrontMatter) {
+                try {
+                    text = removeFromFrontMatter(text, tag);
+                } catch (e) {
+                    return this.skip(e, `Could not process frontmatter of ${this.filename}`);
+                }
+            }
+            if (text !== original) {
+                await this.app.vault.modify(file, text);
+                return true;
+            }
+        } catch (e) {
+            return this.skip(e, `Could not update ${this.filename}`);
+        }
+    }
+
+    /** Warn about a skipped note and signal it to the caller. */
+    skip(e, message) {
+        new Notice(message + "; skipping");
+        console.error(message, e);
+        return "skipped";
+    }
     /** @param {Replacement} replace */
     replaceInFrontMatter(text, replace) {
         const [empty, frontMatter] = text.split(/^---\r?$\n?/m, 2);

--- a/src/File.js
+++ b/src/File.js
@@ -41,17 +41,29 @@ export class File {
 
     /** @param {import("./Tag").Tag} tag */
     async removed(tag) {
-        // Never let one note abort the whole bulk run: any failure (I/O, changed
-        // file, bad frontmatter) warns and skips that note, reported as "skipped".
+        // Never let one note abort the whole bulk run, and never let a note the
+        // scan matched drop out of the tally silently: any hard failure warns and
+        // skips; a note left unchanged is surfaced too, so the tag can't quietly
+        // survive a run the user is told "completed".
         try {
             const file = this.app.vault.getAbstractFileByPath(this.filename);
             const original = await this.app.vault.read(file);
-            let text;
+            let text = original;
+
+            // The inline pass is guarded against a body that changed since the scan.
+            // If it no longer matches we skip the inline edits but still attempt the
+            // frontmatter, which is removed against the current on-disk text — so a
+            // stale body no longer aborts an otherwise-safe frontmatter removal.
+            let inlineStale = false;
             try {
-                text = removeInlineTags(original, this.tagPositions);
+                text = removeInlineTags(text, this.tagPositions);
             } catch (e) {
-                return this.skip(e, `File ${this.filename} has changed`);
+                inlineStale = true;
+                console.error(`Inline tags in ${this.filename} changed since scan; leaving them`, e);
+                if (e && e.found !== undefined)
+                    console.debug("expected", JSON.stringify(e.expected), "but found", JSON.stringify(e.found));
             }
+
             if (this.hasFrontMatter) {
                 try {
                     text = removeFromFrontMatter(text, tag);
@@ -59,10 +71,20 @@ export class File {
                     return this.skip(e, `Could not process frontmatter of ${this.filename}`);
                 }
             }
+
             if (text !== original) {
                 await this.app.vault.modify(file, text);
-                return true;
+                return inlineStale ? "partial" : true;
             }
+            // Matched by the scan but nothing was removed: the file changed since
+            // the scan, or the tag sits in a shape the transforms don't rewrite.
+            // Report it instead of dropping it from both tallies.
+            return this.skip(
+                new Error(`#${tag.name} not removed from ${this.filename}`),
+                inlineStale
+                    ? `${this.filename} changed since scan; #${tag.name} not removed`
+                    : `${this.filename} still contains #${tag.name} in an unsupported form`
+            );
         } catch (e) {
             return this.skip(e, `Could not update ${this.filename}`);
         }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,5 @@
 import {Component, Keymap, Menu, Notice, parseFrontMatterAliases, Plugin} from "obsidian";
-import {renameTag, findTargets} from "./renaming";
+import {renameTag, removeTag, findTargets} from "./renaming";
 import {Tag} from "./Tag";
 import {around} from "monkey-around";
 import {Confirm, use} from "@ophidian/core";
@@ -251,6 +251,7 @@ export default class TagWrangler extends Plugin {
             random = this.app.plugins.plugins["smart-random-note"]
         ;
         menu.addItem(item("tag-rename", "pencil", "Rename #"+tagName, () => this.rename(tagName)))
+        menu.addItem(item("tag-rename", "trash", "Remove #"+tagName+" from all notes", () => this.remove(tagName)))
 
         if (tagPage) {
             menu.addItem(
@@ -299,6 +300,11 @@ export default class TagWrangler extends Plugin {
 
     async rename(tagName, toName=tagName) {
         try { await renameTag(this.app, tagName, toName); }
+        catch (e) { console.error(e); new Notice("error: " + e); }
+    }
+
+    async remove(tagName) {
+        try { await removeTag(this.app, tagName); }
         catch (e) { console.error(e); new Notice("error: " + e); }
     }
 

--- a/src/removal.js
+++ b/src/removal.js
@@ -4,11 +4,13 @@ import { Tag } from "./Tag";
 // Raised when a recorded tag position no longer matches the file's current
 // text (the file changed between the scan and the removal pass).
 export class TagMismatchError extends Error {
-    constructor(start, end) {
+    constructor(start, end, found, expected) {
         super(`Tag position ${start}..${end} no longer matches file text`);
         this.name = "TagMismatchError";
         this.start = start;
         this.end = end;
+        this.found = found;       // the text now at the recorded span
+        this.expected = expected; // the tag the scan recorded there
     }
 }
 
@@ -68,7 +70,7 @@ export function removeInlineTags(text, tagPositions) {
     );
     for (const { position: { start, end }, tag } of ordered) {
         if (text.slice(start.offset, end.offset) !== tag) {
-            throw new TagMismatchError(start.offset, end.offset);
+            throw new TagMismatchError(start.offset, end.offset, text.slice(start.offset, end.offset), tag);
         }
         text = removeInlineTag(text, start.offset, end.offset);
     }
@@ -104,16 +106,34 @@ export function removeFromFrontMatter(text, tag) {
         const node = pair.value;
 
         if (isSeq(node)) {
-            const kept = node.items.filter(it => !matches(isScalar(it) ? it.value : it));
-            if (kept.length === node.items.length) continue;             // nothing matched
-            if (kept.length === 0) { edits.push(fieldRemoval(frontMatter, pair)); continue; }
+            // A single element may itself contain whitespace-separated tags, which
+            // Obsidian treats as distinct — so match per token and keep survivors.
+            const classify = (it) => {
+                const val = isScalar(it) ? it.value : it;
+                if (typeof val !== "string") return { kind: "keep" };
+                const toks = String(val).split(/\s+/).filter(Boolean);
+                const survivors = toks.filter(t => !matches(t));
+                if (survivors.length === toks.length) return { kind: "keep" };  // no token matched
+                if (survivors.length === 0) return { kind: "drop" };            // whole element goes
+                return { kind: "edit", value: survivors.join(" ") };            // keep the rest
+            };
+            const status = node.items.map(classify);
+            if (status.every(s => s.kind === "keep")) continue;              // nothing matched
+            if (status.every(s => s.kind === "drop")) { edits.push(fieldRemoval(frontMatter, pair)); continue; }
             if (node.flow) {
-                const inner = kept.map(it => frontMatter.slice(it.range[0], it.range[1])).join(", ");
+                const inner = node.items
+                    .map((it, i) => status[i].kind === "drop" ? null
+                        : status[i].kind === "edit" ? renderScalarValue(status[i].value)
+                        : frontMatter.slice(it.range[0], it.range[1]))
+                    .filter(v => v !== null)
+                    .join(", ");
                 edits.push({ start: node.range[0], end: node.range[1], replacement: "[" + inner + "]" });
             } else {
-                for (const it of node.items) {
-                    if (matches(isScalar(it) ? it.value : it)) edits.push(lineRemoval(frontMatter, it.range[0]));
-                }
+                node.items.forEach((it, i) => {
+                    if (status[i].kind === "drop") edits.push(lineRemoval(frontMatter, it.range[0]));
+                    else if (status[i].kind === "edit")
+                        edits.push({ start: it.range[0], end: it.range[1], replacement: renderScalarValue(status[i].value) });
+                });
             }
         } else if (isScalar(node) && typeof node.value === "string") {
             const value = String(node.value);

--- a/src/removal.js
+++ b/src/removal.js
@@ -1,0 +1,193 @@
+import { parseDocument, isSeq, isScalar, Document } from "yaml";
+import { Tag } from "./Tag";
+
+// Raised when a recorded tag position no longer matches the file's current
+// text (the file changed between the scan and the removal pass).
+export class TagMismatchError extends Error {
+    constructor(start, end) {
+        super(`Tag position ${start}..${end} no longer matches file text`);
+        this.name = "TagMismatchError";
+        this.start = start;
+        this.end = end;
+    }
+}
+
+// Raised when a file's frontmatter cannot be parsed, so the caller can warn and
+// skip the file rather than write a half-processed note (mirrors the rename path).
+export class FrontMatterParseError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "FrontMatterParseError";
+    }
+}
+
+// A line whose only non-tag content is optional indentation and a single list
+// marker ("-", "*", "+", "1.", "1)") — removing the tag should drop the line.
+const LIST_MARKER_LINE = /^\s*([-*+]|\d+[.)])?\s*$/;
+const CLOSERS = { "(": ")", "[": "]", "{": "}" };
+
+// Remove a single inline tag occupying [start, end).
+//   - Tag alone on its line (or only a bullet + the tag) -> remove the line.
+//   - Tag wrapped in a bracket pair -> remove the brackets too.
+//   - Otherwise -> remove the tag plus one adjacent space (prefer trailing).
+export function removeInlineTag(text, start, end) {
+    const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+    let lineEnd = text.indexOf("\n", end);
+    if (lineEnd === -1) lineEnd = text.length;
+
+    const before = text.slice(lineStart, start);
+    const after = text.slice(end, lineEnd);
+
+    if (LIST_MARKER_LINE.test(before) && after.trim() === "") {
+        if (lineEnd < text.length) {
+            return text.slice(0, lineStart) + text.slice(lineEnd + 1);
+        }
+        // Last line with no trailing newline: drop the preceding line break (\n or \r\n).
+        let dropFrom = lineStart;
+        if (lineStart > 0) {
+            dropFrom = lineStart - 1;
+            if (dropFrom > 0 && text[dropFrom - 1] === "\r") dropFrom -= 1;
+        }
+        return text.slice(0, dropFrom) + text.slice(lineEnd);
+    }
+
+    let s = start, e = end;
+    if (CLOSERS[text[s - 1]] && text[e] === CLOSERS[text[s - 1]]) { s -= 1; e += 1; }
+    if (text[e] === " " || text[e] === "\t") e += 1;
+    else if (s > 0 && (text[s - 1] === " " || text[s - 1] === "\t")) s -= 1;
+    return text.slice(0, s) + text.slice(e);
+}
+
+// Remove every inline tag in `tagPositions` from `text`. Positions are sorted
+// highest-offset-first internally so earlier offsets stay valid as text is cut,
+// making the result independent of the caller's ordering. Throws
+// TagMismatchError if a recorded position no longer matches the file text.
+export function removeInlineTags(text, tagPositions) {
+    const ordered = [...tagPositions].sort(
+        (a, b) => b.position.start.offset - a.position.start.offset
+    );
+    for (const { position: { start, end }, tag } of ordered) {
+        if (text.slice(start.offset, end.offset) !== tag) {
+            throw new TagMismatchError(start.offset, end.offset);
+        }
+        text = removeInlineTag(text, start.offset, end.offset);
+    }
+    return text;
+}
+
+// Remove `tag` (and its sub-tags) from the `tags:`/`tag:` fields of a file's
+// YAML frontmatter. Matching is done on parsed AST values (never raw source, so
+// quoted tags still match). Edits are source-range splices, so unrelated fields,
+// comments, and quoting are preserved byte-for-byte; only the edited field can
+// change shape. A field emptied of tags is removed entirely. `aliases:` is left
+// untouched. Throws FrontMatterParseError on malformed frontmatter; returns the
+// text unchanged if nothing matched.
+export function removeFromFrontMatter(text, tag) {
+    const parts = text.split(/^---\r?$\n?/m, 2);
+    const [empty, frontMatter] = parts;
+
+    if (parts.length < 2 || empty.trim() !== "" || !frontMatter || !frontMatter.trim() || !frontMatter.endsWith("\n"))
+        return text;
+
+    const doc = parseDocument(frontMatter);
+    if (doc.errors.length) throw new FrontMatterParseError(doc.errors[0].message);
+
+    const items = doc.contents && doc.contents.items;
+    if (!items) return text;
+
+    const matches = (val) => typeof val === "string" && tag.matches(Tag.toTag(val));
+    const edits = [];
+
+    for (const pair of items) {
+        const prop = pair.key && pair.key.value;
+        if (typeof prop !== "string" || !/^tags?$/i.test(prop)) continue;
+        const node = pair.value;
+
+        if (isSeq(node)) {
+            const kept = node.items.filter(it => !matches(isScalar(it) ? it.value : it));
+            if (kept.length === node.items.length) continue;             // nothing matched
+            if (kept.length === 0) { edits.push(fieldRemoval(frontMatter, pair)); continue; }
+            if (node.flow) {
+                const inner = kept.map(it => frontMatter.slice(it.range[0], it.range[1])).join(", ");
+                edits.push({ start: node.range[0], end: node.range[1], replacement: "[" + inner + "]" });
+            } else {
+                for (const it of node.items) {
+                    if (matches(isScalar(it) ? it.value : it)) edits.push(lineRemoval(frontMatter, it.range[0]));
+                }
+            }
+        } else if (isScalar(node) && typeof node.value === "string") {
+            const value = String(node.value);
+            const parsedToks = value.split(/[\s,]+/).filter(Boolean);
+            const keptToks = parsedToks.filter(t => !matches(t));
+            if (keptToks.length === parsedToks.length) continue;         // nothing matched
+            if (keptToks.length === 0) { edits.push(fieldRemoval(frontMatter, pair)); continue; }
+
+            const quoted = frontMatter.slice(node.range[0], node.range[1]) !== value;
+            if (quoted) {
+                // Re-render only the VALUE (correct quoting) and splice over the value's
+                // span, so the key, any trailing comment, and the line's EOL are preserved.
+                edits.push({ start: node.range[0], end: node.range[1], replacement: renderScalarValue(keptToks.join(" ")) });
+            } else {
+                editPlainScalar(frontMatter, node, matches, edits);      // preserves original separators
+            }
+        }
+    }
+
+    if (!edits.length) return text;
+
+    edits.sort((a, b) => b.start - a.start);
+    let fm = frontMatter;
+    for (const e of edits) fm = fm.slice(0, e.start) + e.replacement + fm.slice(e.end);
+
+    // Slice-based splice (no regex) so nothing in `fm` is interpreted.
+    const at = text.indexOf(frontMatter);
+    return text.slice(0, at) + fm + text.slice(at + frontMatter.length);
+}
+
+// Full source span of a field: from the start of its key line to the end of its
+// value's last line (trailing newline included).
+function fieldSpan(fm, pair) {
+    const keyStart = pair.key.range[0];
+    const start = fm.lastIndexOf("\n", keyStart - 1) + 1;
+    const valueEnd = pair.value.range[1];
+    const nl = fm.indexOf("\n", Math.max(valueEnd - 1, keyStart));
+    const end = nl === -1 ? fm.length : nl + 1;
+    return [start, end];
+}
+
+function fieldRemoval(fm, pair) {
+    const [start, end] = fieldSpan(fm, pair);
+    return { start, end, replacement: "" };
+}
+
+// Drop the whole source line containing `offset`.
+function lineRemoval(fm, offset) {
+    const start = fm.lastIndexOf("\n", offset - 1) + 1;
+    let end = fm.indexOf("\n", offset);
+    end = end === -1 ? fm.length : end + 1;
+    return { start, end, replacement: "" };
+}
+
+// Plain (unquoted) scalar: drop matching tokens plus one adjacent separator,
+// preserving the original separator style (commas vs spaces).
+function editPlainScalar(fm, node, matches, edits) {
+    const [start, end] = node.range;
+    const parts = fm.slice(start, end).split(/([\s,]+)/); // even = token, odd = separator
+    for (let i = parts.length - 1; i >= 0; i -= 2) {      // length is always odd
+        if (!matches(parts[i])) continue;
+        if (i + 1 < parts.length) parts.splice(i, 2);
+        else if (i - 1 >= 0) parts.splice(i - 1, 2);
+        else parts.splice(i, 1);
+    }
+    const out = parts.join("").replace(/^[\s,]+|[\s,]+$/g, "");
+    edits.push({ start, end, replacement: out });
+}
+
+// Render a scalar value via the YAML library so quoting/escaping stays correct.
+function renderScalarValue(value) {
+    const tmp = new Document();
+    tmp.contents = tmp.createNode(value);
+    // lineWidth:0 disables folding — a bare value has no key indentation, so a
+    // folded continuation line would splice in at column 0 and corrupt the YAML.
+    return tmp.toString({ lineWidth: 0 }).replace(/\n$/, "");
+}

--- a/src/renaming.js
+++ b/src/renaming.js
@@ -38,11 +38,46 @@ export async function renameTag(app, tagName, toName=tagName) {
     return new Notice(`Operation ${progress.aborted ? "cancelled" : "complete"}: ${renamed} file(s) updated`);
 }
 
+export async function removeTag(app, tagName) {
+    const tag = new Tag(tagName);
+    // Removal never touches aliases, so alias-only files must not inflate the count.
+    const targets = await findTargets(app, tag, {includeAliases: false});
+    if (!targets) return;  // search cancelled
+    if (!targets.length) {
+        return new Notice(`No notes contain #${tag.name} or its sub-tags.`);
+    }
+
+    const proceed = await new Confirm()
+        .setTitle(`Remove #${tag.name} and its sub-tags?`)
+        .setContent(
+            activeWindow.createEl("p", undefined, el => { el.innerHTML =
+                `This will remove <code>#${tag.name}</code> (and any sub-tags) from <b>${
+                    targets.length}</b> note(s).<br><br>This <b>cannot</b> be undone.`;
+            })
+        )
+        .setup(c => { c.setOk("Remove"); c.okButton.addClass("mod-warning"); })
+        .confirm();
+    if (!proceed) return;
+
+    const progress = new Progress(`Removing #${tag.name}/*`, "Processing files...");
+    let removed = 0, skipped = 0;
+    await progress.forEach(targets, async (target) => {
+        progress.message = "Processing " + target.basename;
+        const result = await target.removed(tag);
+        if (result === true) removed++;
+        else if (result === "skipped") skipped++;
+    });
+
+    let summary = `Operation ${progress.aborted ? "cancelled" : "complete"}: ${removed} file(s) updated`;
+    if (skipped) summary += `; ${skipped} skipped due to errors (see console)`;
+    return new Notice(summary);
+}
+
 function allTags(app) {
     return Object.keys(app.metadataCache.getTags());
 }
 
-export async function findTargets(app, tag) {
+export async function findTargets(app, tag, {includeAliases = true} = {}) {
     const targets = [];
     const progress = new Progress(`Searching for ${tag}/*`, "Matching files...");
     await progress.forEach(
@@ -51,7 +86,9 @@ export async function findTargets(app, tag) {
             let { frontmatter, tags } = app.metadataCache.getCache(filename) || {};
             tags = (tags || []).filter(t => t.tag && tag.matches(t.tag)).reverse(); // last positions first
             const fmtags = (parseFrontMatterTags(frontmatter) || []).filter(tag.matches);
-            const aliasTags = (parseFrontMatterAliases(frontmatter) || []).filter(Tag.isTag).filter(tag.matches);
+            const aliasTags = includeAliases
+                ? (parseFrontMatterAliases(frontmatter) || []).filter(Tag.isTag).filter(tag.matches)
+                : [];
             if (tags.length || fmtags.length || aliasTags.length)
                 targets.push(new File(app, filename, tags, fmtags.length + aliasTags.length));
         }

--- a/src/renaming.js
+++ b/src/renaming.js
@@ -60,16 +60,18 @@ export async function removeTag(app, tagName) {
     if (!proceed) return;
 
     const progress = new Progress(`Removing #${tag.name}/*`, "Processing files...");
-    let removed = 0, skipped = 0;
+    let removed = 0, partial = 0, skipped = 0;
     await progress.forEach(targets, async (target) => {
         progress.message = "Processing " + target.basename;
         const result = await target.removed(tag);
         if (result === true) removed++;
+        else if (result === "partial") { removed++; partial++; }
         else if (result === "skipped") skipped++;
     });
 
     let summary = `Operation ${progress.aborted ? "cancelled" : "complete"}: ${removed} file(s) updated`;
-    if (skipped) summary += `; ${skipped} skipped due to errors (see console)`;
+    if (partial) summary += ` (${partial} only partly — a changed file left some tags; see console)`;
+    if (skipped) summary += `; ${skipped} skipped (see console)`;
     return new Notice(summary);
 }
 

--- a/test/File.test.js
+++ b/test/File.test.js
@@ -1,0 +1,55 @@
+import { describe, test, expect, vi } from "vitest";
+
+// obsidian ships only type declarations, so stub the tiny runtime surface File.js uses.
+vi.mock("obsidian", () => ({ Notice: class { constructor(message) { this.message = message; } } }));
+
+import { File } from "../src/File.js";
+import { Tag } from "../src/Tag.js";
+
+function fakeApp(content) {
+    const store = { content };
+    return {
+        store,
+        vault: {
+            getAbstractFileByPath: (path) => ({ path }),
+            read: async () => store.content,
+            modify: async (_file, text) => { store.content = text; },
+        },
+    };
+}
+
+function inlinePos(text, needle, tag) {
+    const start = text.indexOf(needle);
+    return { position: { start: { offset: start }, end: { offset: start + needle.length } }, tag };
+}
+
+describe("File.removed — bulk-run safety", () => {
+    test("removes the tag and reports success", async () => {
+        const app = fakeApp("---\ntags: [project, keep]\n---\nbody\n");
+        const result = await new File(app, "note.md", [], true).removed(new Tag("project"));
+        expect(result).toBe(true);
+        expect(app.store.content).toContain("keep");
+        expect(app.store.content).not.toContain("project");
+    });
+
+    test("a matched note left unchanged is surfaced as skipped, never silently dropped", async () => {
+        // hasFrontMatter, but the tag isn't present in a form the transforms rewrite:
+        // removed() must not return undefined (which vanishes from every tally).
+        const original = "---\nfoo: bar\n---\nbody\n";
+        const app = fakeApp(original);
+        const result = await new File(app, "note.md", [], true).removed(new Tag("project"));
+        expect(result).toBe("skipped");
+        expect(app.store.content).toBe(original); // untouched
+    });
+
+    test("a body changed since the scan still gets its frontmatter cleaned (partial)", async () => {
+        const original = "---\ntags: [project, keep]\n---\nthe body no longer has the tag\n";
+        const app = fakeApp(original);
+        // recorded inline position now points at text that no longer matches the tag
+        const stale = [inlinePos(original, "the body", "#project")];
+        const result = await new File(app, "note.md", stale, true).removed(new Tag("project"));
+        expect(result).toBe("partial");                 // inline stale, but frontmatter still cleaned
+        expect(app.store.content).toContain("keep");
+        expect(app.store.content).not.toContain("project");
+    });
+});

--- a/test/removal.test.js
+++ b/test/removal.test.js
@@ -153,3 +153,37 @@ describe("removeFromFrontMatter — preserves unrelated content", () => {
         expect(out).not.toContain("project");
     });
 });
+
+describe("removeFromFrontMatter — whitespace-separated tags inside one element", () => {
+    test("flow element with spaces: only the matching token is dropped", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags: [foo, a project b, bar]\n---\nx\n", new Tag("project"))))
+            .toEqual(["foo", "a b", "bar"]);
+    });
+    test("block element with spaces: only the matching token is dropped", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags:\n  - a project b\n---\nx\n", new Tag("project"))))
+            .toEqual(["a b"]);
+    });
+    test("element whose every token matches is dropped entirely", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags: [keep, project project/deep]\n---\nx\n", new Tag("project"))))
+            .toEqual(["keep"]);
+    });
+    test("a found-but-untouched shape used to survive silently — now the token is removed", () => {
+        const out = removeFromFrontMatter("---\ntags: [a project b]\n---\nx\n", new Tag("project"));
+        expect(out).not.toContain("project");
+        expect(fmTags(out)).toEqual(["a b"]);
+    });
+});
+
+describe("TagMismatchError diagnostics", () => {
+    test("carries the found vs expected text so a changed-file skip is debuggable", () => {
+        const positions = [{ position: { start: { offset: 4 }, end: { offset: 12 } }, tag: "#project" }];
+        try {
+            removeInlineTags("foo bar baz", positions);
+            throw new Error("expected removeInlineTags to throw");
+        } catch (e) {
+            expect(e).toBeInstanceOf(TagMismatchError);
+            expect(e.expected).toBe("#project");
+            expect(e.found).toBe("bar baz");
+        }
+    });
+});

--- a/test/removal.test.js
+++ b/test/removal.test.js
@@ -1,0 +1,155 @@
+import { describe, test, expect } from "vitest";
+import { parseDocument } from "yaml";
+import { Tag } from "../src/Tag.js";
+import {
+    removeInlineTag,
+    removeInlineTags,
+    removeFromFrontMatter,
+    TagMismatchError,
+    FrontMatterParseError,
+} from "../src/removal.js";
+
+function pos(text, tagText, from = 0) {
+    const start = text.indexOf(tagText, from);
+    return { position: { start: { offset: start }, end: { offset: start + tagText.length } }, tag: tagText };
+}
+
+// Parse the `tags`/`tag` field back out of a file's frontmatter for assertions.
+// Returns undefined if the field is absent.
+function fmTags(text) {
+    const fm = text.split(/^---\r?$\n?/m, 2)[1];
+    const json = parseDocument(fm).toJSON() || {};
+    return json.tags ?? json.tag;
+}
+function fmValid(text) {
+    const fm = text.split(/^---\r?$\n?/m, 2)[1];
+    return parseDocument(fm).errors.length === 0;
+}
+function fmHasKey(text, key) {
+    const fm = text.split(/^---\r?$\n?/m, 2)[1];
+    return Object.prototype.hasOwnProperty.call(parseDocument(fm).toJSON() || {}, key);
+}
+
+describe("removeInlineTag", () => {
+    const cut = (text, tag = "#project") => {
+        const s = text.indexOf(tag);
+        return removeInlineTag(text, s, s + tag.length);
+    };
+    test("mid-line: collapses the doubled space", () => expect(cut("foo #project bar")).toBe("foo bar"));
+    test("end of content line: no trailing space", () => expect(cut("foo #project")).toBe("foo"));
+    test("alone on its own line: line removed", () => expect(cut("line1\n#project\nline3")).toBe("line1\nline3"));
+    test("alone at EOF (no trailing newline): line removed", () => expect(cut("line1\n#project")).toBe("line1"));
+    test("alone at EOF on a CRLF file: no orphaned carriage return", () => expect(cut("line1\r\n#project")).toBe("line1"));
+    test("only a bullet + the tag: whole list line removed", () => expect(cut("intro\n- #project\nouttro")).toBe("intro\nouttro"));
+    test("wrapped in parentheses: brackets removed too, no dangling ()", () => expect(cut("text (#project) here")).toBe("text here"));
+    test("wrapped in square brackets: no dangling []", () => expect(cut("see [#project] now")).toBe("see now"));
+});
+
+describe("removeInlineTags", () => {
+    test("removes multiple occurrences (positions last-first)", () => {
+        const text = "a #foo b #foo c";
+        expect(removeInlineTags(text, [pos(text, "#foo", 9), pos(text, "#foo", 0)])).toBe("a b c");
+    });
+    test("order-independent: correct even when positions are document-order", () => {
+        const text = "a #foo b #foo c";
+        expect(removeInlineTags(text, [pos(text, "#foo", 0), pos(text, "#foo", 9)])).toBe("a b c");
+    });
+    test("throws TagMismatchError when the recorded position no longer matches", () => {
+        const positions = [{ position: { start: { offset: 4 }, end: { offset: 12 } }, tag: "#project" }];
+        expect(() => removeInlineTags("foo bar baz", positions)).toThrow(TagMismatchError);
+    });
+});
+
+describe("removeFromFrontMatter — matching & removal", () => {
+    test("removes an entry from a flow array", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags: [a, project, b]\n---\nx\n", new Tag("project")))).toEqual(["a", "b"]);
+    });
+    test("removes an item from a block list", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags:\n  - a\n  - project\n  - b\n---\nx\n", new Tag("project")))).toEqual(["a", "b"]);
+    });
+    test("removes a token from a plain space-separated scalar", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags: a project b\n---\nx\n", new Tag("project")))).toBe("a b");
+    });
+    test("removes sub-tags of the given tag (subtree scope)", () => {
+        expect(fmTags(removeFromFrontMatter("---\ntags: [project/work, other]\n---\nx\n", new Tag("project")))).toEqual(["other"]);
+    });
+    test("matches and removes a quoted single scalar (was silently surviving)", () => {
+        const out = removeFromFrontMatter('---\ntags: "project"\nother: 1\n---\nx\n', new Tag("project"));
+        expect(fmHasKey(out, "tags")).toBe(false);      // emptied field removed
+        expect(fmTags(out)).toBeUndefined();
+    });
+    test("removes one tag from a quoted multi-tag scalar, keeping correct quoting", () => {
+        const out = removeFromFrontMatter("---\ntags: '#project #keep'\n---\nx\n", new Tag("project"));
+        expect(fmTags(out)).toBe("#keep");              // '#keep' must stay quoted to remain a tag
+    });
+    test("leaves aliases untouched even when they are tag-aliases", () => {
+        const out = removeFromFrontMatter('---\naliases:\n  - "#project"\ntags: [project]\n---\nx\n', new Tag("project"));
+        expect(out).toContain("#project");              // alias survives
+        expect(fmHasKey(out, "tags")).toBe(false);
+    });
+    test("preserves a trailing comment when a quoted scalar survives removal", () => {
+        const out = removeFromFrontMatter('---\ntags: "#a #b" # keep this\n---\nx\n', new Tag("a"));
+        expect(out).toContain("# keep this");
+        expect(fmTags(out)).toBe("#b");
+    });
+    test("preserves CRLF line endings when re-rendering a quoted scalar", () => {
+        const out = removeFromFrontMatter('---\r\ntags: "#a #b"\r\nx: 1\r\n---\r\nbody\r\n', new Tag("a"));
+        expect(out).toContain('"#b"\r\n');
+    });
+    test("returns the text unchanged when there is no frontmatter", () => {
+        const text = "just a body with #project inline\n";
+        expect(removeFromFrontMatter(text, new Tag("project"))).toBe(text);
+    });
+    test("throws FrontMatterParseError on malformed frontmatter", () => {
+        expect(() => removeFromFrontMatter("---\ntags: [a, project\nbad: : :\n---\nx\n", new Tag("project"))).toThrow(FrontMatterParseError);
+    });
+});
+
+    test("re-renders a long surviving quoted scalar as valid single-line YAML", () => {
+        const survivors = Array.from({ length: 12 }, (_, i) => `alpha/topic${i}`);
+        const text = `---\ntags: "${survivors.join(" ")} removeme"\n---\nbody\n`;
+        const out = removeFromFrontMatter(text, new Tag("removeme"));
+        expect(fmValid(out)).toBe(true);                 // no column-0 fold corruption
+        expect(fmTags(out)).toBe(survivors.join(" "));   // every survivor intact
+        expect(out).not.toContain("removeme");
+    });
+
+describe("removeFromFrontMatter — emptied fields are removed", () => {
+    test("flow array emptied -> field removed", () => {
+        const out = removeFromFrontMatter("---\ntags: [project]\nother: 1\n---\nx\n", new Tag("project"));
+        expect(fmHasKey(out, "tags")).toBe(false);
+        expect(fmHasKey(out, "other")).toBe(true);
+    });
+    test("block list emptied -> field removed", () => {
+        const out = removeFromFrontMatter("---\ntags:\n  - project\nother: 2\n---\nx\n", new Tag("project"));
+        expect(fmHasKey(out, "tags")).toBe(false);
+        expect(fmHasKey(out, "other")).toBe(true);
+    });
+    test("scalar emptied -> field removed, no quoted-empty-string artifact", () => {
+        const out = removeFromFrontMatter("---\ntags: project\nother: 3\n---\nx\n", new Tag("project"));
+        expect(out).not.toContain('tags:');
+        expect(fmHasKey(out, "other")).toBe(true);
+    });
+});
+
+describe("removeFromFrontMatter — preserves unrelated content", () => {
+    test("preserves unrelated fields with leading zeros", () => {
+        expect(removeFromFrontMatter("---\nnumber: 007\ntags: [a, project, b]\n---\nx\n", new Tag("project"))).toContain("number: 007");
+    });
+    test("preserves an unrelated YAML comment", () => {
+        expect(removeFromFrontMatter("---\ntags: [a, project]\nnote: keep  # important\n---\nx\n", new Tag("project"))).toContain("# important");
+    });
+    test("does not misinterpret $-patterns in unrelated values", () => {
+        const text = "---\nnote: a $& b\ntags: [project]\n---\nbody\n";
+        expect(removeFromFrontMatter(text, new Tag("project"))).toBe("---\nnote: a $& b\n---\nbody\n");
+    });
+    test("preserves comma separators in a plain scalar tags field", () => {
+        expect(removeFromFrontMatter("---\ntags: a, project, b\n---\nx\n", new Tag("project"))).toContain("tags: a, b");
+    });
+    test("preserves the exact source of surviving block-list items", () => {
+        const out = removeFromFrontMatter("---\ntags:\n  - a\n  - project\n  - b\n---\nx\n", new Tag("project"));
+        expect(out).toContain("  - a\n");
+        expect(out).toContain("  - b\n");
+        expect(out).not.toContain("project");
+    });
+});


### PR DESCRIPTION
## What

Adds a **"Remove #tag from all notes"** action to the shared tag context menu (tag pane, reading view, edit mode, and the properties tag pill), alongside the existing Rename. It removes the tag and its whole sub-tree from every note after a count-and-confirm dialog, reusing the existing `findTargets` / `Progress` / `Confirm` machinery and `File.renamed()`-style vault iteration.

## How

- New pure removal transforms in `src/removal.js`:
  - `removeInlineTag` / `removeInlineTags` — cut inline `#tag` occurrences, collapse the resulting whitespace, drop own-line occurrences, and guard against files that changed since the scan.
  - `removeFromFrontMatter` — drop matching elements from `tags:` / `tag:` fields in all three YAML shapes (flow array, block list, and space/comma string); leaves `aliases:` untouched.
- Wired via `File.removed()`, `renaming.removeTag()`, and `plugin.remove()`.

## Tests

Includes a small **vitest** setup with 13 cases covering the removal transforms (inline + all three front-matter shapes, whitespace collapse, sub-tree matching, no-op safety). This adds vitest as a dev dependency (the repo currently has no test runner). **Happy to drop the test tooling and keep just the feature code if you'd rather not take on a test dependency** — just say the word.

No behavior change to existing Rename paths; the version bump / release files are intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)